### PR TITLE
GitHub Actions CI を設定する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.9", "3.12"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Install dependencies
+        run: uv sync --all-extras
+      - name: Run tests
+        run: uv run pytest


### PR DESCRIPTION
## Summary
- GitHub Actions CI ワークフローを追加
- OS (ubuntu, windows, macos) × Python (3.9, 3.12) のマトリクステストを実行
- push/PR 時に `uv sync --all-extras` + `uv run pytest` で自動検証

Closes #17

## Test plan
- [ ] CI が全6マトリクス（3 OS × 2 Python）で正常に完了することを確認
- [ ] テストが全て pass することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)