### PR TITLE
issue #24, #25 のバグ修正: 打ち切り戻り値の不整合と脚注番号の重複

### DIFF
--- a/v2.1.0/excel2md/runner.py
+++ b/v2.1.0/excel2md/runner.py
@@ -189,6 +189,7 @@ def run(input_path: str, output_path: Optional[str], args):
                     current_md_lines.append(f"### Table {table_id}")
                 for (n, txt) in note_refs:
                     footnotes.append((n, txt))
+                global_footnote_start += len(note_refs)
 
                 if not md_rows:
                     current_md_lines.append("（テーブルなし）\n")

--- a/v2.1.0/excel2md/runner.py
+++ b/v2.1.0/excel2md/runner.py
@@ -270,9 +270,10 @@ def run(input_path: str, output_path: Optional[str], args):
                     # CSV Markdownではcolumn_headers/heuristicモード非対応（テーブル分割なしのため）
                     warn(f"mermaid_detect_mode='{detect_mode}' is not supported for CSV markdown output (only 'shapes' is supported). Mermaid output will be skipped for sheet '{sname}'.")
 
-        # split_by_sheetモード: シートごとの脚注を保存・出力
-        if split_by_sheet:
-            sheet_footnotes_dict[sname] = list(footnotes)
+        # シート単位スコープの脚注を保存・出力
+        if split_by_sheet or opts["footnote_scope"] == "sheet":
+            if split_by_sheet:
+                sheet_footnotes_dict[sname] = list(footnotes)
             if footnotes and opts["hyperlink_mode"] in ("footnote", "both"):
                 footnotes_sorted = sorted(set(footnotes), key=lambda x: x[0])
                 current_md_lines.append("\n")
@@ -281,7 +282,7 @@ def run(input_path: str, output_path: Optional[str], args):
 
     # 通常モード: ドキュメント末尾に脚注を追加
     if not split_by_sheet:
-        if footnotes and opts["hyperlink_mode"] in ("footnote", "both"):
+        if opts["footnote_scope"] != "sheet" and footnotes and opts["hyperlink_mode"] in ("footnote", "both"):
             footnotes_sorted = sorted(set(footnotes), key=lambda x: x[0])
             md_lines.append("\n")
             for idx, txt in footnotes_sorted:

--- a/v2.1.0/excel2md/table_extraction.py
+++ b/v2.1.0/excel2md/table_extraction.py
@@ -202,7 +202,7 @@ def extract_table(ws, table, opts, footnotes, footnote_index_start, merged_looku
         for C in used_cols:
             count_cells += 1
             if count_cells > max_cells:
-                return md_rows, note_refs, True
+                return md_rows, note_refs, True, table_title
             if (R,C) not in mask:
                 row_vals.append("")
                 continue

--- a/v2.1.0/tests/test_markdown_output.py
+++ b/v2.1.0/tests/test_markdown_output.py
@@ -297,21 +297,12 @@ class TestExtractTable:
         merged_lookup = build_merged_lookup(ws)
         footnotes = []
 
-        # extract_table returns 3 values when truncated, 4 values normally
-        result = extract_table(
+        md_rows, note_refs, truncated, title = extract_table(
             ws, table, opts, footnotes, 1, merged_lookup
         )
 
-        # Should be truncated (4 cells > 2 limit)
-        # When truncated, returns (md_rows, note_refs, True)
-        # When not truncated, returns (md_rows, note_refs, False, title)
-        if len(result) == 3:
-            md_rows, note_refs, truncated = result
-            assert truncated is True
-        else:
-            md_rows, note_refs, truncated, title = result
-            # May not be truncated if processing is different
-            assert isinstance(truncated, bool)
+        # 4 cells > 2 limit -> must be truncated, and return must always be 4-tuple
+        assert truncated is True
 
     def test_empty_table(self, empty_workbook, default_opts):
         """Empty table extraction."""

--- a/v2.1.0/tests/test_runner_regression.py
+++ b/v2.1.0/tests/test_runner_regression.py
@@ -9,7 +9,6 @@ import tempfile
 from pathlib import Path
 
 import openpyxl
-import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -152,10 +151,11 @@ class TestIssue25FootnoteNumbering:
             run(str(xlsx), str(out_md), args)
 
             text = out_md.read_text(encoding="utf-8")
-            # Each sheet has one link; with sheet scope both start at 1.
-            # The aggregated tail-of-document definitions still reflect the
-            # last-seen footnote list (book-mode bookkeeping in runner), so
-            # the important check here is that the runner does not crash and
-            # produces refs starting from 1 for the first sheet.
-            refs, _ = _footnote_refs_and_defs(text)
-            assert refs.count(1) >= 1
+            refs, defs = _footnote_refs_and_defs(text)
+
+            # Each sheet has one link; with sheet scope each sheet starts at 1.
+            assert refs.count(1) >= 2, f"refs={refs}"
+            assert defs == [
+                (1, "https://example.com/s1"),
+                (1, "https://example.com/s2"),
+            ]

--- a/v2.1.0/tests/test_runner_regression.py
+++ b/v2.1.0/tests/test_runner_regression.py
@@ -1,0 +1,161 @@
+"""Regression tests for runner-level bugs.
+
+Issue #24: extract_table truncation path must return a 4-tuple (was 3-tuple).
+Issue #25: footnote numbering must be unique across tables within the configured scope.
+"""
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+import openpyxl
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from excel2md.cli import build_argparser
+from excel2md.runner import run
+
+
+def _parse_args(argv):
+    return build_argparser().parse_args(argv)
+
+
+def _make_two_table_workbook(path: Path, with_links: bool = True) -> None:
+    """Two tables on one sheet, separated by an empty row.
+
+    When ``with_links`` is True, each table contains exactly one external
+    hyperlink so footnote numbering is exercised.
+    """
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Sheet1"
+    ws["A1"] = "Header1"
+    ws["B1"] = "Header2"
+    ws["A2"] = "Link1"
+    if with_links:
+        ws["A2"].hyperlink = "https://example.com/a"
+    ws["B2"] = "Data1"
+    # Row 3 is empty -> tables split
+    ws["A4"] = "Header3"
+    ws["B4"] = "Header4"
+    ws["A5"] = "Link2"
+    if with_links:
+        ws["A5"].hyperlink = "https://example.com/b"
+    ws["B5"] = "Data2"
+    wb.save(path)
+
+
+def _make_multi_sheet_workbook(path: Path) -> None:
+    """Two sheets, each with a table containing a hyperlink."""
+    wb = openpyxl.Workbook()
+    ws1 = wb.active
+    ws1.title = "S1"
+    ws1["A1"] = "H1"
+    ws1["B1"] = "H2"
+    ws1["A2"] = "L1"
+    ws1["A2"].hyperlink = "https://example.com/s1"
+    ws1["B2"] = "V1"
+
+    ws2 = wb.create_sheet("S2")
+    ws2["A1"] = "H1"
+    ws2["B1"] = "H2"
+    ws2["A2"] = "L2"
+    ws2["A2"].hyperlink = "https://example.com/s2"
+    ws2["B2"] = "V2"
+    wb.save(path)
+
+
+# ============================================================
+# Issue #24: truncation return tuple must be 4 elements
+# ============================================================
+
+class TestIssue24Truncation:
+    """runner.run() must not crash when max_cells_per_table forces truncation."""
+
+    def test_truncation_does_not_crash_runner(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            xlsx = Path(tmpdir) / "trunc.xlsx"
+            _make_two_table_workbook(xlsx, with_links=False)
+            out_md = Path(tmpdir) / "out.md"
+
+            args = _parse_args([
+                str(xlsx),
+                "-o", str(out_md),
+                "--no-csv-markdown-enabled",
+                "--max-cells-per-table", "2",
+            ])
+
+            # Pre-fix this raised ValueError: not enough values to unpack
+            result = run(str(xlsx), str(out_md), args)
+            assert result is not None
+            assert Path(result).exists()
+            text = Path(result).read_text(encoding="utf-8")
+            assert "max_cells_per_table" in text
+
+
+# ============================================================
+# Issue #25: footnote IDs unique across tables
+# ============================================================
+
+_REF_RE = re.compile(r"\[\^(\d+)\]")
+_DEF_RE = re.compile(r"^\[\^(\d+)\]:\s*(.+)$", re.MULTILINE)
+
+
+def _footnote_refs_and_defs(text: str):
+    refs = [int(n) for n in _REF_RE.findall(text)]
+    defs = [(int(n), body.strip()) for n, body in _DEF_RE.findall(text)]
+    return refs, defs
+
+
+class TestIssue25FootnoteNumbering:
+    """Footnote numbers must be unique and sequential within the configured scope."""
+
+    def test_book_scope_footnotes_are_unique_and_sequential(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            xlsx = Path(tmpdir) / "book.xlsx"
+            _make_two_table_workbook(xlsx, with_links=True)
+            out_md = Path(tmpdir) / "out.md"
+
+            args = _parse_args([
+                str(xlsx),
+                "-o", str(out_md),
+                "--no-csv-markdown-enabled",
+                "--hyperlink-mode", "footnote",
+                "--footnote-scope", "book",
+            ])
+            run(str(xlsx), str(out_md), args)
+
+            text = out_md.read_text(encoding="utf-8")
+            refs, defs = _footnote_refs_and_defs(text)
+
+            # Two hyperlinks -> two distinct footnote refs (in body and definitions)
+            assert sorted(set(refs)) == [1, 2], f"refs={refs}"
+            # Definitions must be unique and contain the two distinct URLs
+            assert sorted(n for n, _ in defs) == [1, 2]
+            def_urls = {body for _, body in defs}
+            assert def_urls == {"https://example.com/a", "https://example.com/b"}
+
+    def test_sheet_scope_resets_per_sheet(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            xlsx = Path(tmpdir) / "sheet.xlsx"
+            _make_multi_sheet_workbook(xlsx)
+            out_md = Path(tmpdir) / "out.md"
+
+            args = _parse_args([
+                str(xlsx),
+                "-o", str(out_md),
+                "--no-csv-markdown-enabled",
+                "--hyperlink-mode", "footnote",
+                "--footnote-scope", "sheet",
+            ])
+            run(str(xlsx), str(out_md), args)
+
+            text = out_md.read_text(encoding="utf-8")
+            # Each sheet has one link; with sheet scope both start at 1.
+            # The aggregated tail-of-document definitions still reflect the
+            # last-seen footnote list (book-mode bookkeeping in runner), so
+            # the important check here is that the runner does not crash and
+            # produces refs starting from 1 for the first sheet.
+            refs, _ = _footnote_refs_and_defs(text)
+            assert refs.count(1) >= 1


### PR DESCRIPTION
## Summary

- **#24**: `extract_table()` の `max_cells_per_table` 超過分岐で 3 要素 `(md_rows, note_refs, True)` を返していたため、`runner.run()` の 4 要素 unpack で `ValueError: not enough values to unpack` が発生し得る状態でした。`table_title` を含む 4 要素戻り値に統一しました。
- **#25**: `runner.run()` が各テーブルの `extract_table()` 呼び出しに同じ `global_footnote_start=1` を渡し続けていたため、複数テーブルで `[^1]` から再採番され、脚注定義が重複・参照先が曖昧になる状態でした。テーブル処理後に `note_refs` の長さだけ開始番号を前進させ、`footnote_scope=book` で全体連番、`footnote_scope=sheet` ではシート切替時のリセットと組み合わせてシート単位の連番になるよう修正しました。

## 変更箇所

- ` v2.1.0/excel2md/table_extraction.py`: 打ち切り分岐の戻り値を 4 要素に統一
- ` v2.1.0/excel2md/runner.py`: テーブル抽出後に `global_footnote_start += len(note_refs)` を追加
- ` v2.1.0/tests/test_markdown_output.py`: `test_max_cells_truncation` の「3 要素 or 4 要素」分岐を削り、4 要素 + `truncated is True` を直接アサート
- ` v2.1.0/tests/test_runner_regression.py` (新規): runner.run() レベルの回帰テスト
  - 打ち切り時にクラッシュせず打ち切り注記が出力されること (#24)
  - book scope で脚注番号が `1, 2` の連番になり定義も重複しないこと (#25)
  - sheet scope でシートごとに番号がリセットされること (#25 関連)

## Test plan

- [x] `uv run pytest tests/` — 256 件すべて PASS（うち回帰テスト 3 件は本 PR で追加）
- [ ] レビュー時にバグ再現手順を試す場合は、修正前ブランチで `--max-cells-per-table 2` 指定 / 複数テーブル+`--hyperlink-mode footnote` を実行し、症状を確認

Closes #24
Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)