### PR TITLE
issue #15: v1.x 互換のため is_code_block / build_code_block_from_rows を再エクスポート

### DIFF
--- a/v2.1.0/excel2md/__init__.py
+++ b/v2.1.0/excel2md/__init__.py
@@ -2,3 +2,14 @@
 """excel2md package (v2.1.0)."""
 
 __version__ = "2.1.0"
+
+# Backward-compatible re-exports for the v1.x public API surface
+# (see issue #15 — these symbols moved into submodules in v2.x and stopped
+# being importable from ``excel2md`` / ``excel_to_md``).
+from .table_formatting import is_code_block, build_code_block_from_rows
+
+__all__ = [
+    "__version__",
+    "is_code_block",
+    "build_code_block_from_rows",
+]

--- a/v2.1.0/excel_to_md.py
+++ b/v2.1.0/excel_to_md.py
@@ -48,6 +48,8 @@ from excel2md.table_detection import (
 from excel2md.table_extraction import detect_table_title, extract_table, dispatch_table_output
 from excel2md.table_formatting import (
     is_source_code,
+    is_code_block,
+    build_code_block_from_rows,
     detect_code_language,
     format_table_as_text_or_nested,
     choose_header_row_heuristic,
@@ -103,6 +105,8 @@ __all__ = [
     "has_border",
     "dispatch_table_output",
     "is_source_code",
+    "is_code_block",
+    "build_code_block_from_rows",
     "detect_code_language",
     "format_table_as_text_or_nested",
     "choose_header_row_heuristic",

--- a/v2.1.0/tests/test_public_api.py
+++ b/v2.1.0/tests/test_public_api.py
@@ -1,0 +1,57 @@
+"""Regression tests for the public API surface.
+
+Issue #15: ``is_code_block`` and ``build_code_block_from_rows`` were importable
+from the top-level ``excel_to_md`` module in v1.8 but were dropped from the
+v2.x public surface. They must remain importable from both ``excel2md`` and
+``excel_to_md`` for backward compatibility.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+_JAVA_ROWS = [
+    ["public class Example {"],
+    ["    private int value;"],
+    ["}"],
+]
+
+
+def test_is_code_block_importable_from_excel2md_package():
+    from excel2md import is_code_block
+
+    assert callable(is_code_block)
+    assert is_code_block(_JAVA_ROWS) is True
+    assert is_code_block([["Name", "Value"], ["Item", "1"]]) is False
+
+
+def test_build_code_block_from_rows_importable_from_excel2md_package():
+    from excel2md import build_code_block_from_rows
+
+    assert callable(build_code_block_from_rows)
+    out = build_code_block_from_rows(_JAVA_ROWS)
+    assert out is not None
+    assert "public class Example" in out
+
+
+def test_is_code_block_importable_from_excel_to_md_facade():
+    from excel_to_md import is_code_block
+
+    assert callable(is_code_block)
+
+
+def test_build_code_block_from_rows_importable_from_excel_to_md_facade():
+    from excel_to_md import build_code_block_from_rows
+
+    assert callable(build_code_block_from_rows)
+
+
+def test_same_callable_across_paths():
+    """Re-exports must point at the canonical implementation, not copies."""
+    from excel2md import is_code_block as via_pkg
+    from excel_to_md import is_code_block as via_facade
+    from excel2md.table_formatting import is_code_block as canonical
+
+    assert via_pkg is canonical
+    assert via_facade is canonical


### PR DESCRIPTION
## Summary

- v2.0 のモジュール分割で `is_code_block` と `build_code_block_from_rows` が `table_formatting.py` に切り出された結果、トップレベルの `excel_to_md` / `excel2md` パッケージから import できなくなっていました。v1.8 では `excel_to_md.is_code_block` が公開API として参照可能だったため、後方互換性が崩れています。
- 両関数を `v2.1.0/excel2md/__init__.py` と `v2.1.0/excel_to_md.py` の双方から再エクスポートし、`from excel2md import is_code_block` / `from excel_to_md import is_code_block` のどちらのパターンでも動作するように戻します。

## 変更箇所

- ` v2.1.0/excel2md/__init__.py`: `from .table_formatting import is_code_block, build_code_block_from_rows` を追加し、明示的な `__all__` を設定
- ` v2.1.0/excel_to_md.py`: 既存ファサードの `from excel2md.table_formatting import ...` と `__all__` に両関数を追加
- ` v2.1.0/tests/test_public_api.py` (新規): 両パスからの import 可否、関数オブジェクトが canonical 実装と同一であること、簡単な動作確認の回帰テストを追加

## Test plan

- [x] `uv run pytest tests/` — 261件 PASS（うち本PRで追加した5件含む）
- [x] `from excel2md import is_code_block, build_code_block_from_rows` が成功し、canonical 実装 (`excel2md.table_formatting.is_code_block`) と同一オブジェクトであることを確認
- [x] `from excel_to_md import is_code_block, build_code_block_from_rows` も同様に成功することを確認

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)