### PR TITLE
issue #14: CSV Markdown で画像位置による印刷領域拡張をやめる

### DIFF
--- a/v2.1.0/excel2md/runner.py
+++ b/v2.1.0/excel2md/runner.py
@@ -231,17 +231,10 @@ def run(input_path: str, output_path: Optional[str], args):
                 cell_to_image = extract_images_from_sheet(ws, Path(csv_output_dir), sname, csv_basename, opts, xlsx_path=input_path)
 
             # CSVデータ収集
+            # 仕様 §「印刷領域内のみが変換対象となる」を満たすため、画像位置で
+            # union_area を拡張しない。印刷領域外の画像は extract_print_area_for_csv
+            # 側の範囲反復で自然にフィルタされる。
             for union_area in unioned:
-                # 画像位置を含むように範囲を拡張
-                if cell_to_image:
-                    min_r, min_c, max_r, max_c = union_area
-                    for (img_row, img_col) in cell_to_image.keys():
-                        min_r = min(min_r, img_row)
-                        min_c = min(min_c, img_col)
-                        max_r = max(max_r, img_row)
-                        max_c = max(max_c, img_col)
-                    union_area = (min_r, min_c, max_r, max_c)
-
                 merged_lookup = build_merged_lookup(ws, union_area)
                 try:
                     csv_rows = extract_print_area_for_csv(ws, union_area, opts, merged_lookup, cell_to_image)

--- a/v2.1.0/tests/test_runner_regression.py
+++ b/v2.1.0/tests/test_runner_regression.py
@@ -2,6 +2,7 @@
 
 Issue #24: extract_table truncation path must return a 4-tuple (was 3-tuple).
 Issue #25: footnote numbering must be unique across tables within the configured scope.
+Issue #14: CSV markdown must not expand the print area to cover image positions.
 """
 import re
 import sys
@@ -12,6 +13,7 @@ import openpyxl
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from excel2md import runner as runner_module
 from excel2md.cli import build_argparser
 from excel2md.runner import run
 
@@ -159,3 +161,67 @@ class TestIssue25FootnoteNumbering:
                 (1, "https://example.com/s1"),
                 (1, "https://example.com/s2"),
             ]
+
+
+# ============================================================
+# Issue #14: CSV markdown must respect the print area, not expand
+# the union_area to cover image positions outside it.
+# ============================================================
+
+
+def _make_workbook_with_print_area(path: Path) -> None:
+    """Workbook whose print area is A1:B2 but with data also at C5/D6.
+
+    Used to verify the CSV markdown range stays inside the print area even
+    when images are reported at out-of-area positions.
+    """
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "S"
+    ws["A1"] = "h1"
+    ws["B1"] = "h2"
+    ws["A2"] = "v1"
+    ws["B2"] = "v2"
+    # Cells outside the print area
+    ws["C5"] = "leak-c5"
+    ws["D6"] = "leak-d6"
+    ws.print_area = "A1:B2"
+    wb.save(path)
+
+
+class TestIssue14CsvPrintAreaRespect:
+    """CSV markdown output must stay within the declared print area."""
+
+    def test_out_of_area_image_does_not_expand_range(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            xlsx = Path(tmpdir) / "area.xlsx"
+            _make_workbook_with_print_area(xlsx)
+
+            inside_path = "out/inside.png"
+            outside_path = "out/outside.png"
+
+            def fake_extract_images(ws, output_dir, sheet_name, md_basename, opts, xlsx_path=None):
+                # One image inside the print area (B2) and one outside (E5).
+                return {(2, 2): inside_path, (5, 5): outside_path}
+
+            monkeypatch.setattr(runner_module, "extract_images_from_sheet", fake_extract_images)
+
+            args = _parse_args([
+                str(xlsx),
+                "--csv-output-dir", tmpdir,
+            ])
+            result = run(str(xlsx), None, args)
+            assert result is not None
+
+            out_files = list(Path(tmpdir).glob("*.md"))
+            assert out_files, "expected at least one CSV markdown output file"
+            text = "\n".join(p.read_text(encoding="utf-8") for p in out_files)
+
+            # The declared range must remain the print area.
+            assert "A1:B2" in text, text
+            # The inside image must appear; the outside one must NOT.
+            assert inside_path in text
+            assert outside_path not in text
+            # Out-of-area data cells must not leak into the CSV output either.
+            assert "leak-c5" not in text
+            assert "leak-d6" not in text


### PR DESCRIPTION
## Summary

- `runner.run()` の CSVデータ収集ループで、画像位置に合わせて `union_area` を拡張していたため、印刷領域外のセルや画像参照が CSV Markdown 出力と検証メタデータに混入していました。仕様（[v2.1.0/spec.md:730 「印刷領域内のみが変換対象となる」](https://github.com/elvezjp/excel2md/blob/main/v2.1.0/spec.md#L730)）および v1.8 までの挙動と矛盾していたため、当該拡張処理を撤去しました。
- `extract_print_area_for_csv()` は `area` の範囲で反復しているため、印刷領域外の `cell_to_image` エントリは自動的に無視され、画像参照やセル値が出力に漏れません。

## 変更箇所

- ` v2.1.0/excel2md/runner.py`: 画像位置による `union_area` 拡張ブロック（旧 lines 233-242）を削除し、仕様準拠を明示するコメントに置き換え
- ` v2.1.0/tests/test_runner_regression.py`: 印刷領域 `A1:B2` + 領域外の値セル (`C5`, `D6`) と画像 `(5,5)` を持つ workbook を組み立て、出力レンジが `A1:B2` のままで、領域外の画像・セル値が混入しないことを assert する回帰テストを追加（`extract_images_from_sheet` は monkeypatch で既知のマップを返す）

## 既知の残課題（本 PR スコープ外）

- `extract_images_from_sheet` 自体は呼び出されたままなので、印刷領域外の画像ファイルがディスクに保存される副作用は残ります。Issue #14 は `runner.py:233-242` の範囲拡張に限定された指摘なので、画像ファイル抽出側の領域フィルタリングは別タスクで切るのが適切と判断しました。必要なら新 Issue としてフォローアップします。

## Test plan

- [x] `uv run pytest tests/` — 262件 PASS（うち本PRで追加した1件含む）
- [x] 修正前の挙動: 印刷領域 `A1:B2` 設定でも、領域外 `(5,5)` の画像があると range が `A1:E5` まで拡張され、`C5`/`D6` の値も CSV に混入していた
- [x] 修正後の挙動: 印刷領域内 `(2,2)` の画像リンクは出力されるが、領域外 `(5,5)` の画像リンクおよび `C5`/`D6` セル値は出力されない

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)