### PR TITLE
issue #16: ライブラリとして再利用可能な公開 API を整備

### DIFF
--- a/v2.1.1/excel2md/__init__.py
+++ b/v2.1.1/excel2md/__init__.py
@@ -3,6 +3,10 @@
 
 __version__ = "2.1.1"
 
+# ライブラリとしての公開 API (issue #16)
+from .config import ConversionConfig
+from .converter import ExcelConverter, convert_to_markdown
+
 # Backward-compatible re-exports for the v1.x public API surface
 # (see issue #15 — these symbols moved into submodules in v2.x and stopped
 # being importable from ``excel2md`` / ``excel_to_md``).
@@ -10,6 +14,9 @@ from .table_formatting import is_code_block, build_code_block_from_rows
 
 __all__ = [
     "__version__",
+    "ConversionConfig",
+    "ExcelConverter",
+    "convert_to_markdown",
     "is_code_block",
     "build_code_block_from_rows",
 ]

--- a/v2.1.1/excel2md/config.py
+++ b/v2.1.1/excel2md/config.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+"""ConversionConfig — Python ネイティブな変換設定を表現する dataclass。
+
+Issue #16 (excel2md をライブラリとして再利用可能にするリファクタリング) の Phase 1。
+CLI 以外の呼び出し元（Web デモ、MCP サーバー、ノートブック等）が
+argparse.Namespace を組み立てずに済むようにする。
+
+このコミット時点では `runner.run()` はまだこの dataclass を使っていない。
+PR D で runner 側を ConversionConfig ベースに置換する際、`to_opts_dict()` の
+出力が現在 `runner.run()` で組み立てている opts 辞書と **完全に一致** することを
+test_config.py の roundtrip テストで担保している。
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class ConversionConfig:
+    """Excel→Markdown 変換の設定を保持する。
+
+    フィールドは現在の CLI (cli.py の build_argparser) と 1:1 で対応し、
+    既定値も argparse と同一。CLI の文字列（"first_row"/"numbers_right" 等）は
+    そのまま文字列として保持し、内部の bool 化や辞書展開は to_opts_dict() に
+    一元化する。
+    """
+
+    # ----- General -----
+    read_only: bool = False
+    split_by_sheet: bool = False
+
+    # ----- Print area / value handling -----
+    no_print_area_mode: str = "used_range"          # used_range / entire_sheet_range / skip_sheet
+    value_mode: str = "display"                     # display / formula / both
+    merge_policy: str = "top_left_only"             # expand / repeat / warn / top_left_only
+    hyperlink_mode: str = "footnote"                # inline / inline_plain / footnote / both / text_only
+    header_detection: str = "first_row"             # none / first_row / heuristic (string; runner expects bool)
+    hidden_policy: str = "ignore"                   # ignore / include / exclude
+
+    # ----- Whitespace / escaping -----
+    strip_whitespace: bool = True
+    escape_pipes: bool = True
+
+    # ----- Date / number formatting -----
+    date_format_override: Optional[str] = None
+    date_default_format: str = "YYYY-MM-DD"
+    numeric_thousand_sep: str = "keep"              # keep / remove
+    percent_format: str = "keep"                    # keep / numeric
+    currency_symbol: str = "keep"                   # keep / strip
+    percent_divide_100: bool = False
+
+    # ----- Misc -----
+    readonly_fill_policy: str = "assume_no_fill"
+    align_detection: str = "numbers_right"          # none / numbers_right (string; runner expects bool)
+    numbers_right_threshold: float = 0.8
+    max_sheet_count: int = 0                        # 0 = unlimited
+    max_cells_per_table: int = 200000
+    sort_tables: str = "document_order"
+    footnote_scope: str = "book"                    # book / sheet
+    locale: str = "ja-JP"
+    markdown_escape_level: str = "safe"             # safe / minimal / aggressive
+    prefer_excel_display: bool = True
+
+    # ----- Mermaid -----
+    mermaid_enabled: bool = False
+    mermaid_detect_mode: str = "shapes"             # none / column_headers / heuristic / shapes
+    mermaid_diagram_type: str = "flowchart"
+    mermaid_direction: str = "TD"
+    mermaid_keep_source_table: bool = True
+    mermaid_dedupe_edges: bool = True
+    mermaid_node_id_policy: str = "auto"
+    mermaid_group_column_behavior: str = "subgraph"
+    mermaid_columns: str = "From,To,Label,Group,Note"  # CSV string; expanded to dict in to_opts_dict()
+    mermaid_heuristic_min_rows: int = 3
+    mermaid_heuristic_arrow_ratio: float = 0.3
+    mermaid_heuristic_len_median_ratio_min: float = 0.4
+    mermaid_heuristic_len_median_ratio_max: float = 2.5
+    dispatch_skip_code_and_mermaid_on_fallback: bool = True
+
+    # ----- CSV markdown -----
+    csv_output_dir: Optional[str] = None
+    csv_apply_merge_policy: bool = True
+    csv_normalize_values: bool = True
+    csv_markdown_enabled: bool = True
+    csv_include_metadata: bool = True
+    csv_include_description: bool = True
+
+    # ----- Image extraction -----
+    image_extraction: bool = True
+
+    # =============================================================
+    # Factories / converters
+    # =============================================================
+
+    @classmethod
+    def from_args(cls, args: Any) -> "ConversionConfig":
+        """argparse.Namespace から ConversionConfig を構築する。
+
+        Namespace に存在しないフィールドはこの dataclass の既定値で埋める
+        （getattr で fallback）。これにより、Namespace 側で `dest` が省かれている
+        オプションがあっても落ちない。
+        """
+        defaults = cls()
+        kwargs = {
+            name: getattr(args, name, getattr(defaults, name))
+            for name in cls.__dataclass_fields__
+        }
+        return cls(**kwargs)
+
+    def to_opts_dict(self) -> Dict[str, Any]:
+        """runner.run() が期待する opts 辞書を返す。
+
+        現状の runner.run() における opts 辞書構築箇所 (v2.1.1/excel2md/runner.py
+        の lines 47-105 相当) と **完全に一致** する辞書を返す。PR D で runner を
+        ConversionConfig ベースに置換する際、この一致が振る舞いの不変性を担保する。
+        test_config.py の test_to_opts_dict_matches_runner_inline_dict_* がこの
+        一致を検証する回帰テスト。
+        """
+        return {
+            "no_print_area_mode": self.no_print_area_mode,
+            "value_mode": self.value_mode,
+            "merge_policy": self.merge_policy,
+            "hyperlink_mode": self.hyperlink_mode,
+            "header_detection": (self.header_detection == "first_row"),
+            "hidden_policy": self.hidden_policy,
+            "strip_whitespace": self.strip_whitespace,
+            "escape_pipes": self.escape_pipes,
+            "date_format_override": self.date_format_override,
+            "date_default_format": self.date_default_format,
+            "numeric_thousand_sep": self.numeric_thousand_sep,
+            "percent_format": self.percent_format,
+            "currency_symbol": self.currency_symbol,
+            "percent_divide_100": self.percent_divide_100,
+            "readonly_fill_policy": self.readonly_fill_policy,
+            "align_detection": (self.align_detection == "numbers_right"),
+            "numbers_right_threshold": self.numbers_right_threshold,
+            "max_sheet_count": self.max_sheet_count,
+            "max_cells_per_table": self.max_cells_per_table,
+            "sort_tables": self.sort_tables,
+            "footnote_scope": self.footnote_scope,
+            "locale": self.locale,
+            "markdown_escape_level": self.markdown_escape_level,
+            "mermaid_enabled": self.mermaid_enabled,
+            "mermaid_detect_mode": self.mermaid_detect_mode,
+            "mermaid_diagram_type": self.mermaid_diagram_type,
+            "mermaid_direction": self.mermaid_direction,
+            "mermaid_keep_source_table": self.mermaid_keep_source_table,
+            "mermaid_dedupe_edges": self.mermaid_dedupe_edges,
+            "mermaid_node_id_policy": self.mermaid_node_id_policy,
+            "mermaid_group_column_behavior": self.mermaid_group_column_behavior,
+            "mermaid_columns": self._parse_mermaid_columns(),
+            "mermaid_heuristic_min_rows": self.mermaid_heuristic_min_rows,
+            "mermaid_heuristic_arrow_ratio": self.mermaid_heuristic_arrow_ratio,
+            "mermaid_heuristic_len_median_ratio_min": self.mermaid_heuristic_len_median_ratio_min,
+            "mermaid_heuristic_len_median_ratio_max": self.mermaid_heuristic_len_median_ratio_max,
+            "dispatch_skip_code_and_mermaid_on_fallback": self.dispatch_skip_code_and_mermaid_on_fallback,
+            "detect_dates": True,  # runner.run() でハードコードされている
+            "prefer_excel_display": self.prefer_excel_display,
+            "csv_output_dir": self.csv_output_dir,
+            "csv_apply_merge_policy": self.csv_apply_merge_policy,
+            "csv_normalize_values": self.csv_normalize_values,
+            "csv_markdown_enabled": self.csv_markdown_enabled,
+            "csv_include_metadata": self.csv_include_metadata,
+            "csv_include_description": self.csv_include_description,
+            "image_extraction": self.image_extraction,
+        }
+
+    def _parse_mermaid_columns(self) -> Dict[str, Optional[str]]:
+        parts = self.mermaid_columns.split(",")
+        return {
+            "from": parts[0].strip() if len(parts) > 0 else "From",
+            "to": parts[1].strip() if len(parts) > 1 else "To",
+            "label": parts[2].strip() if len(parts) > 2 else "Label",
+            "group": parts[3].strip() if len(parts) > 3 else None,
+            "note": parts[4].strip() if len(parts) > 4 else None,
+        }

--- a/v2.1.1/excel2md/converter.py
+++ b/v2.1.1/excel2md/converter.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+"""ExcelConverter — xlsx を Markdown に変換する高水準 API。
+
+Issue #16 Phase 2。ConversionConfig を受け取り、内部で runner.run を
+呼び出す薄いラッパー。bytes 入力にも対応するため、必要に応じて一時
+ファイルを経由する。
+
+PR D で runner.run の内部が ConversionConfig ベースに置換された後は、
+tempfile 経由のステップは不要になり、bytes / 文字列 / Path を直接
+内部に渡せる予定。
+"""
+from __future__ import annotations
+
+import tempfile
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
+
+from .config import ConversionConfig
+from .runner import run as _runner_run
+
+InputType = Union[bytes, str, Path]
+OutputPathType = Union[str, Path]
+
+
+class ExcelConverter:
+    """xlsx を Markdown に変換する高水準 API。
+
+    Examples:
+        >>> from excel2md import ConversionConfig, ExcelConverter
+        >>> cfg = ConversionConfig(hyperlink_mode="inline")
+        >>> result = ExcelConverter(cfg).convert("spec.xlsx")
+        >>> result["markdown"]
+        '# 変換結果: spec.xlsx\\n...'
+    """
+
+    def __init__(self, config: Optional[ConversionConfig] = None):
+        self.config = config if config is not None else ConversionConfig()
+
+    def convert(
+        self,
+        source: InputType,
+        output_path: Optional[OutputPathType] = None,
+    ) -> Dict[str, Any]:
+        """xlsx を Markdown に変換する。
+
+        Args:
+            source: xlsx の中身 (bytes) または既存ファイルへのパス (str / Path)。
+            output_path: Markdown の出力先パス。省略時は一時ディレクトリに生成する。
+                CSV Markdown モード (config.csv_markdown_enabled=True) では runner 側が
+                csv_output_dir を使うため、このパラメータは出力名のヒントとしては
+                使われない。
+
+        Returns:
+            次の辞書を返す:
+
+            ``{
+                "markdown": str,        # 生成された Markdown の中身
+                "output_path": str,     # Markdown が実際に書き出されたパス
+                "result": str,          # runner.run() の生の戻り値 (path / summary)
+            }``
+
+            split_by_sheet=True など複数ファイル出力モードでは、最初に見つかった
+            Markdown ファイルが "markdown" / "output_path" に入る（取りこぼしは
+            "result" に runner からの multi-line サマリーで残る）。
+        """
+        # ----- ①入力をディスク上のパスに正規化する -----
+        workdir: Optional[Path] = None
+        if isinstance(source, (bytes, bytearray)):
+            workdir = Path(tempfile.mkdtemp(prefix="excel2md_"))
+            input_path = str(workdir / "input.xlsx")
+            Path(input_path).write_bytes(bytes(source))
+        else:
+            input_path = str(source)
+
+        # ----- ②出力先を決める -----
+        out_path_str: Optional[str] = str(output_path) if output_path is not None else None
+        if out_path_str is None:
+            if workdir is None:
+                workdir = Path(tempfile.mkdtemp(prefix="excel2md_"))
+            out_path_str = str(workdir / (Path(input_path).stem + ".md"))
+
+        # ----- ③csv_output_dir の暫定差し替え -----
+        # csv_markdown_enabled=True で csv_output_dir 未設定だと、runner は
+        # input_path の親に CSV Markdown を書く。bytes 入力では親が tempdir に
+        # なる、というのは妥当だが、明示的に workdir を渡しておくと挙動が
+        # 予測しやすい。元 config は不変のまま、replace でコピーを作る。
+        cfg = self.config
+        if cfg.csv_markdown_enabled and cfg.csv_output_dir is None and workdir is not None:
+            cfg = replace(cfg, csv_output_dir=str(workdir))
+
+        # ----- ④runner.run に委譲 -----
+        # runner.run は args.foo 形式の属性アクセスしか行わないため、
+        # ConversionConfig インスタンスを args として直接渡せる。
+        result = _runner_run(input_path, out_path_str, cfg)
+
+        # ----- ⑤実際に書き出された Markdown ファイルを探す -----
+        actual_md_path = self._resolve_output_path(result, out_path_str)
+        markdown = actual_md_path.read_text(encoding="utf-8") if actual_md_path else ""
+
+        return {
+            "markdown": markdown,
+            "output_path": str(actual_md_path) if actual_md_path else out_path_str,
+            "result": result,
+        }
+
+    @staticmethod
+    def _resolve_output_path(result: Any, fallback_path: str) -> Optional[Path]:
+        """runner.run の戻り値から実際の Markdown ファイルパスを判定する。"""
+        # ケース 1: 単一の path 文字列 (通常 Markdown モード / 単一 CSV Markdown モード)
+        if isinstance(result, str) and "\n" not in result:
+            candidate = Path(result)
+            if candidate.exists() and candidate.is_file():
+                return candidate
+
+        # ケース 2: split_by_sheet などの multi-line サマリー — 最初の md を採用
+        if isinstance(result, str) and "\n" in result:
+            for line in result.splitlines()[1:]:  # 先頭行は通知文
+                candidate = Path(line.strip())
+                if candidate.exists() and candidate.is_file() and candidate.suffix == ".md":
+                    return candidate
+
+        # ケース 3: fallback_path にファイルが書かれている (通常 Markdown モードの一般)
+        candidate = Path(fallback_path)
+        if candidate.exists() and candidate.is_file():
+            return candidate
+
+        return None

--- a/v2.1.1/excel2md/converter.py
+++ b/v2.1.1/excel2md/converter.py
@@ -104,6 +104,10 @@ class ExcelConverter:
             "result": result,
         }
 
+    # =============================================================
+    # Internal helpers
+    # =============================================================
+
     @staticmethod
     def _resolve_output_path(result: Any, fallback_path: str) -> Optional[Path]:
         """runner.run の戻り値から実際の Markdown ファイルパスを判定する。"""
@@ -126,3 +130,34 @@ class ExcelConverter:
             return candidate
 
         return None
+
+
+# =============================================================
+# Convenience function (one-shot conversion)
+# =============================================================
+
+def convert_to_markdown(
+    source: InputType,
+    output_path: Optional[OutputPathType] = None,
+    **config_kwargs: Any,
+) -> Dict[str, Any]:
+    """``ExcelConverter`` のワンショット版。
+
+    ``ConversionConfig`` を ``config_kwargs`` から組み立て、``ExcelConverter`` に
+    委譲する薄いラッパー。簡単な使い方:
+
+        >>> from excel2md import convert_to_markdown
+        >>> md = convert_to_markdown("spec.xlsx")["markdown"]
+        >>> md_inline = convert_to_markdown(
+        ...     "spec.xlsx", hyperlink_mode="inline"
+        ... )["markdown"]
+        >>> md_from_bytes = convert_to_markdown(open("spec.xlsx", "rb").read())["markdown"]
+
+    細かい設定や複数回の変換には ``ExcelConverter`` を直接使う方が効率的:
+
+        >>> cfg = ConversionConfig(hyperlink_mode="inline")
+        >>> conv = ExcelConverter(cfg)
+        >>> r1 = conv.convert(b1); r2 = conv.convert(b2)
+    """
+    cfg = ConversionConfig(**config_kwargs)
+    return ExcelConverter(cfg).convert(source, output_path=output_path)

--- a/v2.1.1/excel2md/runner.py
+++ b/v2.1.1/excel2md/runner.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import List, Tuple, Optional
 
 from . import __version__ as VERSION
+from .config import ConversionConfig
 from .output import warn, info
 from .workbook_loader import load_workbook_safe, get_print_areas
 from .mermaid_generator import _v14_extract_shapes_to_mermaid
@@ -18,12 +19,20 @@ from .image_extraction import extract_images_from_sheet
 from .csv_export import coords_to_excel_range, write_csv_markdown, extract_print_area_for_csv
 
 def run(input_path: str, output_path: Optional[str], args):
-    """Excel→Markdown変換のメイン処理を実行する。"""
+    """Excel→Markdown変換のメイン処理を実行する。
+
+    ``args`` には argparse.Namespace (CLI 経由) または ConversionConfig
+    (ライブラリ呼び出し / ExcelConverter 経由) のいずれも渡せる。両者は
+    同じ属性インタフェースを持つが、内部処理は ConversionConfig に
+    正規化して扱う (Issue #16 Phase 4)。
+    """
+    config = args if isinstance(args, ConversionConfig) else ConversionConfig.from_args(args)
+
     # ワークブック読み込み
-    wb = load_workbook_safe(input_path, read_only=args.read_only)
+    wb = load_workbook_safe(input_path, read_only=config.read_only)
     sheets = wb.sheetnames
 
-    split_by_sheet = getattr(args, "split_by_sheet", False)
+    split_by_sheet = config.split_by_sheet
 
     # split_by_sheetモード: シートごとにMarkdown行と脚注を管理
     if split_by_sheet:
@@ -44,65 +53,11 @@ def run(input_path: str, output_path: Optional[str], args):
     sheet_counter = 0
 
     # オプション辞書の構築
-    opts = {
-        "no_print_area_mode": args.no_print_area_mode,
-        "value_mode": args.value_mode,
-        "merge_policy": args.merge_policy,
-        "hyperlink_mode": args.hyperlink_mode,
-        "header_detection": (args.header_detection == "first_row"),
-        "hidden_policy": args.hidden_policy,
-        "strip_whitespace": args.strip_whitespace,
-        "escape_pipes": args.escape_pipes,
-        "date_format_override": args.date_format_override,
-        "date_default_format": args.date_default_format,
-        "numeric_thousand_sep": args.numeric_thousand_sep,
-        "percent_format": args.percent_format,
-        "currency_symbol": args.currency_symbol,
-        "percent_divide_100": args.percent_divide_100,
-        "readonly_fill_policy": getattr(args, "readonly_fill_policy", "assume_no_fill"),
-        "align_detection": (args.align_detection == "numbers_right"),
-        "numbers_right_threshold": args.numbers_right_threshold,
-        "max_sheet_count": args.max_sheet_count,
-        "max_cells_per_table": args.max_cells_per_table,
-        "sort_tables": args.sort_tables,
-        "footnote_scope": args.footnote_scope,
-        "locale": args.locale,
-        "markdown_escape_level": args.markdown_escape_level,
-        "mermaid_enabled": args.mermaid_enabled,
-        "mermaid_detect_mode": args.mermaid_detect_mode,
-        "mermaid_diagram_type": getattr(args, "mermaid_diagram_type", "flowchart"),
-        "mermaid_direction": args.mermaid_direction,
-        "mermaid_keep_source_table": getattr(args, "mermaid_keep_source_table", True),
-        "mermaid_dedupe_edges": getattr(args, "mermaid_dedupe_edges", True),
-        "mermaid_node_id_policy": getattr(args, "mermaid_node_id_policy", "auto"),
-        "mermaid_group_column_behavior": getattr(args, "mermaid_group_column_behavior", "subgraph"),
-        "mermaid_columns": (lambda s: {
-            "from": (s.split(",")[0].strip() if len(s.split(","))>0 else "From"),
-            "to": (s.split(",")[1].strip() if len(s.split(","))>1 else "To"),
-            "label": (s.split(",")[2].strip() if len(s.split(","))>2 else "Label"),
-            "group": (s.split(",")[3].strip() if len(s.split(","))>3 else None),
-            "note": (s.split(",")[4].strip() if len(s.split(","))>4 else None),
-        })(args.mermaid_columns),
-        "mermaid_heuristic_min_rows": args.mermaid_heuristic_min_rows,
-        "mermaid_heuristic_arrow_ratio": args.mermaid_heuristic_arrow_ratio,
-        "mermaid_heuristic_len_median_ratio_min": args.mermaid_heuristic_len_median_ratio_min,
-        "mermaid_heuristic_len_median_ratio_max": args.mermaid_heuristic_len_median_ratio_max,
-        "dispatch_skip_code_and_mermaid_on_fallback": getattr(args, "dispatch_skip_code_and_mermaid_on_fallback", True),
-
-        "detect_dates": True,
-        "prefer_excel_display": args.prefer_excel_display,
-
-        # CSV Markdown出力オプション
-        "csv_output_dir": getattr(args, "csv_output_dir", None),
-        "csv_apply_merge_policy": getattr(args, "csv_apply_merge_policy", True),
-        "csv_normalize_values": getattr(args, "csv_normalize_values", True),
-        "csv_markdown_enabled": getattr(args, "csv_markdown_enabled", True),
-        "csv_include_metadata": getattr(args, "csv_include_metadata", True),
-        "csv_include_description": getattr(args, "csv_include_description", True),
-
-        # 画像抽出オプション
-        "image_extraction": getattr(args, "image_extraction", True),
-    }
+    # ConversionConfig.to_opts_dict() がかつての inline 辞書と完全に同等の
+    # 形を返すため、ここでは委譲するだけで振る舞いは変わらない。
+    # test_config.py の test_to_opts_dict_matches_runner_inline_dict_* が
+    # この同等性を回帰テストとして担保している。
+    opts = config.to_opts_dict()
 
     # CSV Markdown出力の準備
     csv_output_dir = opts.get("csv_output_dir") or str(Path(input_path).parent)

--- a/v2.1.1/excel_to_md.py
+++ b/v2.1.1/excel_to_md.py
@@ -7,6 +7,8 @@
 from excel2md.cli import build_argparser, main
 from excel2md.runner import run
 from excel2md import __version__ as VERSION
+from excel2md.config import ConversionConfig
+from excel2md.converter import ExcelConverter, convert_to_markdown
 from excel2md.output import warn, info
 from excel2md.cell_utils import (
     remove_control_chars,
@@ -63,6 +65,9 @@ __all__ = [
     "run",
     "build_argparser",
     "main",
+    "ConversionConfig",
+    "ExcelConverter",
+    "convert_to_markdown",
     "warn",
     "info",
     "remove_control_chars",

--- a/v2.1.1/tests/test_config.py
+++ b/v2.1.1/tests/test_config.py
@@ -1,0 +1,279 @@
+"""Tests for ConversionConfig (issue #16, Phase 1).
+
+The critical test is ``test_to_opts_dict_matches_runner_inline_dict_*`` — it
+verifies that the dict produced by ConversionConfig is exactly the same as
+the dict that ``runner.run()`` currently constructs inline. This roundtrip
+guarantee is what makes the eventual runner refactor a no-op for behavior.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from excel2md.config import ConversionConfig
+from excel2md.cli import build_argparser
+
+
+# =============================================================
+# Snapshot of the inline opts-dict construction currently inside
+# runner.run() (v2.1.1/excel2md/runner.py lines 47-105 as of 2026-05-13).
+# Kept verbatim here as the ground-truth baseline.
+# =============================================================
+
+def _build_opts_dict_inline(args):
+    return {
+        "no_print_area_mode": args.no_print_area_mode,
+        "value_mode": args.value_mode,
+        "merge_policy": args.merge_policy,
+        "hyperlink_mode": args.hyperlink_mode,
+        "header_detection": (args.header_detection == "first_row"),
+        "hidden_policy": args.hidden_policy,
+        "strip_whitespace": args.strip_whitespace,
+        "escape_pipes": args.escape_pipes,
+        "date_format_override": args.date_format_override,
+        "date_default_format": args.date_default_format,
+        "numeric_thousand_sep": args.numeric_thousand_sep,
+        "percent_format": args.percent_format,
+        "currency_symbol": args.currency_symbol,
+        "percent_divide_100": args.percent_divide_100,
+        "readonly_fill_policy": getattr(args, "readonly_fill_policy", "assume_no_fill"),
+        "align_detection": (args.align_detection == "numbers_right"),
+        "numbers_right_threshold": args.numbers_right_threshold,
+        "max_sheet_count": args.max_sheet_count,
+        "max_cells_per_table": args.max_cells_per_table,
+        "sort_tables": args.sort_tables,
+        "footnote_scope": args.footnote_scope,
+        "locale": args.locale,
+        "markdown_escape_level": args.markdown_escape_level,
+        "mermaid_enabled": args.mermaid_enabled,
+        "mermaid_detect_mode": args.mermaid_detect_mode,
+        "mermaid_diagram_type": getattr(args, "mermaid_diagram_type", "flowchart"),
+        "mermaid_direction": args.mermaid_direction,
+        "mermaid_keep_source_table": getattr(args, "mermaid_keep_source_table", True),
+        "mermaid_dedupe_edges": getattr(args, "mermaid_dedupe_edges", True),
+        "mermaid_node_id_policy": getattr(args, "mermaid_node_id_policy", "auto"),
+        "mermaid_group_column_behavior": getattr(args, "mermaid_group_column_behavior", "subgraph"),
+        "mermaid_columns": (lambda s: {
+            "from": (s.split(",")[0].strip() if len(s.split(",")) > 0 else "From"),
+            "to": (s.split(",")[1].strip() if len(s.split(",")) > 1 else "To"),
+            "label": (s.split(",")[2].strip() if len(s.split(",")) > 2 else "Label"),
+            "group": (s.split(",")[3].strip() if len(s.split(",")) > 3 else None),
+            "note": (s.split(",")[4].strip() if len(s.split(",")) > 4 else None),
+        })(args.mermaid_columns),
+        "mermaid_heuristic_min_rows": args.mermaid_heuristic_min_rows,
+        "mermaid_heuristic_arrow_ratio": args.mermaid_heuristic_arrow_ratio,
+        "mermaid_heuristic_len_median_ratio_min": args.mermaid_heuristic_len_median_ratio_min,
+        "mermaid_heuristic_len_median_ratio_max": args.mermaid_heuristic_len_median_ratio_max,
+        "dispatch_skip_code_and_mermaid_on_fallback": getattr(args, "dispatch_skip_code_and_mermaid_on_fallback", True),
+        "detect_dates": True,
+        "prefer_excel_display": args.prefer_excel_display,
+        "csv_output_dir": getattr(args, "csv_output_dir", None),
+        "csv_apply_merge_policy": getattr(args, "csv_apply_merge_policy", True),
+        "csv_normalize_values": getattr(args, "csv_normalize_values", True),
+        "csv_markdown_enabled": getattr(args, "csv_markdown_enabled", True),
+        "csv_include_metadata": getattr(args, "csv_include_metadata", True),
+        "csv_include_description": getattr(args, "csv_include_description", True),
+        "image_extraction": getattr(args, "image_extraction", True),
+    }
+
+
+# =============================================================
+# Construction
+# =============================================================
+
+class TestConstruction:
+    def test_default_values_match_cli(self):
+        """ConversionConfig() の既定値が CLI 既定値と一致すること。"""
+        cfg = ConversionConfig()
+        args = build_argparser().parse_args(["dummy.xlsx"])
+        assert cfg.hyperlink_mode == args.hyperlink_mode
+        assert cfg.max_cells_per_table == args.max_cells_per_table
+        assert cfg.csv_markdown_enabled == args.csv_markdown_enabled
+        assert cfg.merge_policy == args.merge_policy
+        assert cfg.footnote_scope == args.footnote_scope
+
+    def test_keyword_construction(self):
+        cfg = ConversionConfig(hyperlink_mode="inline", max_cells_per_table=10)
+        assert cfg.hyperlink_mode == "inline"
+        assert cfg.max_cells_per_table == 10
+        # 他の値は既定のまま
+        assert cfg.footnote_scope == "book"
+
+
+# =============================================================
+# from_args
+# =============================================================
+
+class TestFromArgs:
+    def test_passes_all_fields_through(self):
+        args = build_argparser().parse_args(["dummy.xlsx"])
+        cfg = ConversionConfig.from_args(args)
+        # スポットチェック
+        for fname in ("hyperlink_mode", "max_cells_per_table", "csv_markdown_enabled",
+                      "merge_policy", "mermaid_columns", "footnote_scope"):
+            assert getattr(cfg, fname) == getattr(args, fname), fname
+
+    def test_namespace_without_optional_fields_uses_defaults(self):
+        """getattr のフォールバックが効くこと。"""
+        class Bare:
+            pass
+        bare = Bare()
+        # 必須属性だけ盛る
+        bare.no_print_area_mode = "used_range"
+        bare.value_mode = "display"
+        bare.merge_policy = "top_left_only"
+        bare.hyperlink_mode = "footnote"
+        bare.header_detection = "first_row"
+        bare.hidden_policy = "ignore"
+        bare.strip_whitespace = True
+        bare.escape_pipes = True
+        bare.date_format_override = None
+        bare.date_default_format = "YYYY-MM-DD"
+        bare.numeric_thousand_sep = "keep"
+        bare.percent_format = "keep"
+        bare.currency_symbol = "keep"
+        bare.percent_divide_100 = False
+        bare.align_detection = "numbers_right"
+        bare.numbers_right_threshold = 0.8
+        bare.max_sheet_count = 0
+        bare.max_cells_per_table = 200000
+        bare.sort_tables = "document_order"
+        bare.footnote_scope = "book"
+        bare.locale = "ja-JP"
+        bare.markdown_escape_level = "safe"
+        bare.mermaid_enabled = False
+        bare.mermaid_detect_mode = "shapes"
+        bare.mermaid_direction = "TD"
+        bare.mermaid_columns = "From,To,Label,Group,Note"
+        bare.mermaid_heuristic_min_rows = 3
+        bare.mermaid_heuristic_arrow_ratio = 0.3
+        bare.mermaid_heuristic_len_median_ratio_min = 0.4
+        bare.mermaid_heuristic_len_median_ratio_max = 2.5
+        bare.prefer_excel_display = True
+        bare.read_only = False
+        # readonly_fill_policy, mermaid_diagram_type など、CLI に明示が無いものは
+        # 省略して getattr のフォールバックを試す
+        cfg = ConversionConfig.from_args(bare)
+        assert cfg.readonly_fill_policy == "assume_no_fill"
+        assert cfg.mermaid_diagram_type == "flowchart"
+        assert cfg.csv_markdown_enabled is True
+
+
+# =============================================================
+# to_opts_dict — runner.run() inline 辞書との完全一致
+# =============================================================
+
+class TestOptsDictMatchesRunnerInline:
+    """これが PR D を機械的置換にする保証。"""
+
+    def test_defaults(self):
+        args = build_argparser().parse_args(["dummy.xlsx"])
+        cfg = ConversionConfig.from_args(args)
+        assert cfg.to_opts_dict() == _build_opts_dict_inline(args)
+
+    def test_custom_args(self):
+        args = build_argparser().parse_args([
+            "dummy.xlsx",
+            "--hyperlink-mode", "inline",
+            "--max-cells-per-table", "50",
+            "--mermaid-enabled",
+            "--footnote-scope", "sheet",
+            "--no-strip-whitespace",
+            "--mermaid-columns", "Src,Dst,Edge,Cat,Note",
+            "--markdown-escape-level", "aggressive",
+            "--no-csv-include-metadata",
+        ])
+        cfg = ConversionConfig.from_args(args)
+        assert cfg.to_opts_dict() == _build_opts_dict_inline(args)
+
+    @pytest.mark.parametrize("flag,value", [
+        ("--value-mode", "formula"),
+        ("--merge-policy", "expand"),
+        ("--header-detection", "none"),
+        ("--hidden-policy", "exclude"),
+        ("--numeric-thousand-sep", "remove"),
+        ("--percent-format", "numeric"),
+        ("--currency-symbol", "strip"),
+        ("--align-detection", "none"),
+        ("--mermaid-detect-mode", "heuristic"),
+        ("--mermaid-direction", "LR"),
+        ("--mermaid-node-id-policy", "explicit"),
+    ])
+    def test_individual_choice_args(self, flag, value):
+        args = build_argparser().parse_args(["dummy.xlsx", flag, value])
+        cfg = ConversionConfig.from_args(args)
+        assert cfg.to_opts_dict() == _build_opts_dict_inline(args)
+
+
+# =============================================================
+# 個別変換ルール (header_detection / align_detection / mermaid_columns)
+# =============================================================
+
+class TestStringToBoolCoercion:
+    def test_header_detection_first_row(self):
+        cfg = ConversionConfig(header_detection="first_row")
+        assert cfg.header_detection == "first_row"
+        assert cfg.to_opts_dict()["header_detection"] is True
+
+    def test_header_detection_none(self):
+        cfg = ConversionConfig(header_detection="none")
+        assert cfg.to_opts_dict()["header_detection"] is False
+
+    def test_header_detection_heuristic_is_not_true(self):
+        """heuristic は CLI の選択肢にあるが、runner では first_row のみが True 扱い。"""
+        cfg = ConversionConfig(header_detection="heuristic")
+        assert cfg.to_opts_dict()["header_detection"] is False
+
+    def test_align_detection_numbers_right(self):
+        cfg = ConversionConfig(align_detection="numbers_right")
+        assert cfg.to_opts_dict()["align_detection"] is True
+
+    def test_align_detection_none(self):
+        cfg = ConversionConfig(align_detection="none")
+        assert cfg.to_opts_dict()["align_detection"] is False
+
+
+class TestMermaidColumnsParsing:
+    def test_all_five_fields(self):
+        cfg = ConversionConfig(mermaid_columns="A,B,C,D,E")
+        assert cfg.mermaid_columns == "A,B,C,D,E"  # 生文字列は保持される
+        opts = cfg.to_opts_dict()
+        assert opts["mermaid_columns"] == {
+            "from": "A", "to": "B", "label": "C", "group": "D", "note": "E",
+        }
+
+    def test_three_fields_group_and_note_default_to_none(self):
+        cfg = ConversionConfig(mermaid_columns="X,Y,Z")
+        opts = cfg.to_opts_dict()
+        assert opts["mermaid_columns"]["from"] == "X"
+        assert opts["mermaid_columns"]["to"] == "Y"
+        assert opts["mermaid_columns"]["label"] == "Z"
+        assert opts["mermaid_columns"]["group"] is None
+        assert opts["mermaid_columns"]["note"] is None
+
+    def test_whitespace_trimmed(self):
+        cfg = ConversionConfig(mermaid_columns="A , B , C")
+        opts = cfg.to_opts_dict()
+        assert opts["mermaid_columns"]["from"] == "A"
+        assert opts["mermaid_columns"]["to"] == "B"
+        assert opts["mermaid_columns"]["label"] == "C"
+
+    def test_default_matches_cli(self):
+        """既定値が CLI 側の既定 "From,To,Label,Group,Note" と同じ展開になる。"""
+        cfg = ConversionConfig()
+        opts = cfg.to_opts_dict()
+        assert opts["mermaid_columns"] == {
+            "from": "From", "to": "To", "label": "Label",
+            "group": "Group", "note": "Note",
+        }
+
+
+# =============================================================
+# detect_dates は runner.run でハードコードされている
+# =============================================================
+
+def test_detect_dates_hardcoded_true():
+    cfg = ConversionConfig()
+    assert cfg.to_opts_dict()["detect_dates"] is True

--- a/v2.1.1/tests/test_config.py
+++ b/v2.1.1/tests/test_config.py
@@ -17,9 +17,15 @@ from excel2md.cli import build_argparser
 
 
 # =============================================================
-# Snapshot of the inline opts-dict construction currently inside
-# runner.run() (v2.1.1/excel2md/runner.py lines 47-105 as of 2026-05-13).
-# Kept verbatim here as the ground-truth baseline.
+# Frozen baseline of the inline opts-dict construction that runner.run()
+# *used to* build inline (v2.1.1/excel2md/runner.py lines 47-105 as of
+# 2026-05-13, before Commit D of issue #16).
+#
+# Commit D replaced that inline block with ``config.to_opts_dict()``; from
+# that point this helper stops being "the current runner code" and becomes
+# the **immutable contract reference** that ``to_opts_dict()`` must continue
+# to satisfy. Do not modify it to track later runner changes — instead,
+# update ``to_opts_dict()`` and add new test cases for new behavior.
 # =============================================================
 
 def _build_opts_dict_inline(args):

--- a/v2.1.1/tests/test_converter.py
+++ b/v2.1.1/tests/test_converter.py
@@ -1,0 +1,173 @@
+"""Tests for ExcelConverter (issue #16, Phase 2).
+
+bytes / 文字列 / Path 入力を受け、ConversionConfig に従って Markdown を
+返すことを検証する。runner.run の薄いラッパーとしての振る舞いに重点を置く。
+"""
+import sys
+from pathlib import Path
+
+import openpyxl
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from excel2md.config import ConversionConfig
+from excel2md.converter import ExcelConverter
+
+
+# =============================================================
+# Fixtures
+# =============================================================
+
+def _build_small_xlsx(path: Path) -> None:
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "S"
+    ws["A1"] = "h1"
+    ws["B1"] = "h2"
+    ws["A2"] = "v1"
+    ws["B2"] = "v2"
+    wb.save(path)
+
+
+def _build_xlsx_with_link(path: Path) -> None:
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws["A1"] = "Header1"
+    ws["B1"] = "Header2"
+    ws["A2"] = "LinkCell"
+    ws["A2"].hyperlink = "https://example.com"
+    ws["B2"] = "ValueCell"
+    wb.save(path)
+
+
+# =============================================================
+# Construction
+# =============================================================
+
+class TestConstruction:
+    def test_default_config(self):
+        c = ExcelConverter()
+        assert isinstance(c.config, ConversionConfig)
+        # 既定では CLI 既定と同じ
+        assert c.config.csv_markdown_enabled is True
+        assert c.config.hyperlink_mode == "footnote"
+
+    def test_custom_config(self):
+        cfg = ConversionConfig(hyperlink_mode="inline", max_cells_per_table=10)
+        c = ExcelConverter(cfg)
+        assert c.config.hyperlink_mode == "inline"
+        assert c.config.max_cells_per_table == 10
+
+
+# =============================================================
+# convert() — 通常 Markdown モード
+# =============================================================
+
+class TestConvertNormalMarkdown:
+    """csv_markdown_enabled=False で通常 Markdown 出力モードの動作を見る。"""
+
+    def test_from_path_str(self, tmp_path):
+        xlsx = tmp_path / "in.xlsx"
+        _build_small_xlsx(xlsx)
+        cfg = ConversionConfig(csv_markdown_enabled=False)
+        result = ExcelConverter(cfg).convert(str(xlsx))
+        assert {"markdown", "output_path", "result"}.issubset(result.keys())
+        assert result["markdown"]
+        assert "h1" in result["markdown"]
+        assert "v1" in result["markdown"]
+
+    def test_from_path_obj(self, tmp_path):
+        xlsx = tmp_path / "in.xlsx"
+        _build_small_xlsx(xlsx)
+        cfg = ConversionConfig(csv_markdown_enabled=False)
+        result = ExcelConverter(cfg).convert(xlsx)  # Path object
+        assert "h1" in result["markdown"]
+
+    def test_from_bytes(self, tmp_path):
+        xlsx = tmp_path / "in.xlsx"
+        _build_small_xlsx(xlsx)
+        data = xlsx.read_bytes()
+        cfg = ConversionConfig(csv_markdown_enabled=False)
+        result = ExcelConverter(cfg).convert(data)
+        assert "h1" in result["markdown"]
+        assert "v1" in result["markdown"]
+
+    def test_bytes_and_path_give_same_markdown(self, tmp_path):
+        xlsx = tmp_path / "same.xlsx"
+        _build_small_xlsx(xlsx)
+        cfg = ConversionConfig(csv_markdown_enabled=False)
+        out_path = ExcelConverter(cfg).convert(str(xlsx))["markdown"]
+        out_bytes = ExcelConverter(cfg).convert(xlsx.read_bytes())["markdown"]
+        # ファイル名 (input_path.stem) が違うので 1 行目の "変換結果: <name>"
+        # は異なる。それ以外は同じはず。
+        def _strip_header(md):
+            return "\n".join(l for l in md.splitlines() if not l.startswith("# 変換結果"))
+        assert _strip_header(out_path) == _strip_header(out_bytes)
+
+    def test_explicit_output_path(self, tmp_path):
+        xlsx = tmp_path / "in.xlsx"
+        _build_small_xlsx(xlsx)
+        out = tmp_path / "explicit.md"
+        cfg = ConversionConfig(csv_markdown_enabled=False)
+        result = ExcelConverter(cfg).convert(str(xlsx), output_path=str(out))
+        assert out.exists()
+        assert "h1" in out.read_text(encoding="utf-8")
+        assert Path(result["output_path"]) == out
+
+
+# =============================================================
+# convert() — custom config の効果
+# =============================================================
+
+class TestCustomConfigEffect:
+    def test_hyperlink_mode_inline(self, tmp_path):
+        xlsx = tmp_path / "links.xlsx"
+        _build_xlsx_with_link(xlsx)
+        cfg = ConversionConfig(csv_markdown_enabled=False, hyperlink_mode="inline")
+        md = ExcelConverter(cfg).convert(str(xlsx))["markdown"]
+        # inline モードでは URL がセル内に組み込まれる
+        # (md_escape で記号類が \ エスケープされるため部分一致で検査)
+        assert "https" in md and "example" in md
+        # 脚注リファレンスは出ない
+        assert "[^" not in md
+
+    def test_hyperlink_mode_footnote(self, tmp_path):
+        xlsx = tmp_path / "links.xlsx"
+        _build_xlsx_with_link(xlsx)
+        cfg = ConversionConfig(csv_markdown_enabled=False, hyperlink_mode="footnote")
+        md = ExcelConverter(cfg).convert(str(xlsx))["markdown"]
+        assert "[^1]" in md
+        assert "https://example.com" in md
+
+    def test_max_cells_per_table_truncation_does_not_crash(self, tmp_path):
+        """Issue #24 の修正と組み合わさり、ExcelConverter 経由でも crash しない。"""
+        xlsx = tmp_path / "big.xlsx"
+        _build_small_xlsx(xlsx)
+        cfg = ConversionConfig(csv_markdown_enabled=False, max_cells_per_table=2)
+        result = ExcelConverter(cfg).convert(str(xlsx))
+        assert result["markdown"]  # 何らかの中身が返る
+
+
+# =============================================================
+# convert() — CSV Markdown モード (default)
+# =============================================================
+
+class TestConvertCsvMarkdownMode:
+    """csv_markdown_enabled=True の経路で markdown が読み返せること。"""
+
+    def test_default_config_returns_markdown(self, tmp_path):
+        xlsx = tmp_path / "csv.xlsx"
+        _build_small_xlsx(xlsx)
+        result = ExcelConverter().convert(str(xlsx))
+        # CSV Markdown でも markdown キーは何かしらの中身を持つ
+        assert isinstance(result["markdown"], str)
+        # 値が空でないことを確認 (path が解決できているということ)
+        assert result["markdown"], "expected non-empty markdown content from CSV mode"
+
+    def test_bytes_input_in_csv_mode(self, tmp_path):
+        xlsx = tmp_path / "csv.xlsx"
+        _build_small_xlsx(xlsx)
+        result = ExcelConverter().convert(xlsx.read_bytes())
+        assert isinstance(result["markdown"], str)
+        assert result["markdown"]

--- a/v2.1.1/tests/test_public_api.py
+++ b/v2.1.1/tests/test_public_api.py
@@ -4,9 +4,16 @@ Issue #15: ``is_code_block`` and ``build_code_block_from_rows`` were importable
 from the top-level ``excel_to_md`` module in v1.8 but were dropped from the
 v2.x public surface. They must remain importable from both ``excel2md`` and
 ``excel_to_md`` for backward compatibility.
+
+Issue #16 (Phase 3): ``ConversionConfig`` / ``ExcelConverter`` /
+``convert_to_markdown`` should be exposed as the canonical library API from
+both ``excel2md`` and ``excel_to_md``.
 """
 import sys
 from pathlib import Path
+
+import openpyxl
+import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -55,3 +62,121 @@ def test_same_callable_across_paths():
 
     assert via_pkg is canonical
     assert via_facade is canonical
+
+
+# =============================================================
+# Issue #16 — library API surface
+# =============================================================
+
+def test_conversion_config_importable_from_excel2md():
+    from excel2md import ConversionConfig
+
+    cfg = ConversionConfig()
+    assert cfg.hyperlink_mode == "footnote"  # default
+
+
+def test_conversion_config_importable_from_excel_to_md_facade():
+    from excel_to_md import ConversionConfig
+
+    cfg = ConversionConfig(max_cells_per_table=10)
+    assert cfg.max_cells_per_table == 10
+
+
+def test_excel_converter_importable_from_excel2md():
+    from excel2md import ExcelConverter
+
+    conv = ExcelConverter()
+    # 既定値で動作する
+    assert conv.config.csv_markdown_enabled is True
+
+
+def test_excel_converter_importable_from_excel_to_md_facade():
+    from excel_to_md import ExcelConverter
+
+    conv = ExcelConverter()
+    assert conv is not None
+
+
+def test_convert_to_markdown_importable_from_excel2md():
+    from excel2md import convert_to_markdown
+
+    assert callable(convert_to_markdown)
+
+
+def test_convert_to_markdown_importable_from_excel_to_md_facade():
+    from excel_to_md import convert_to_markdown
+
+    assert callable(convert_to_markdown)
+
+
+def test_library_api_objects_are_same_across_paths():
+    from excel2md import (
+        ConversionConfig as CC1,
+        ExcelConverter as EC1,
+        convert_to_markdown as ctm1,
+    )
+    from excel_to_md import (
+        ConversionConfig as CC2,
+        ExcelConverter as EC2,
+        convert_to_markdown as ctm2,
+    )
+
+    assert CC1 is CC2
+    assert EC1 is EC2
+    assert ctm1 is ctm2
+
+
+# =============================================================
+# convert_to_markdown — 動作確認 (薄いラッパーであること)
+# =============================================================
+
+def _build_tiny_xlsx(path: Path) -> None:
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws["A1"] = "h"
+    ws["A2"] = "v"
+    wb.save(path)
+
+
+def test_convert_to_markdown_with_path(tmp_path):
+    from excel2md import convert_to_markdown
+
+    xlsx = tmp_path / "tiny.xlsx"
+    _build_tiny_xlsx(xlsx)
+    result = convert_to_markdown(str(xlsx), csv_markdown_enabled=False)
+    assert "markdown" in result and result["markdown"]
+    assert "h" in result["markdown"]
+
+
+def test_convert_to_markdown_with_bytes(tmp_path):
+    from excel2md import convert_to_markdown
+
+    xlsx = tmp_path / "tiny.xlsx"
+    _build_tiny_xlsx(xlsx)
+    result = convert_to_markdown(xlsx.read_bytes(), csv_markdown_enabled=False)
+    assert "h" in result["markdown"]
+
+
+def test_convert_to_markdown_kwargs_passed_to_config(tmp_path):
+    """config_kwargs が ConversionConfig に正しく渡ること。"""
+    from excel2md import convert_to_markdown
+
+    xlsx = tmp_path / "tiny.xlsx"
+    _build_tiny_xlsx(xlsx)
+    # hyperlink_mode をデフォルトの footnote から inline に変えて違いが出ること
+    # (このテスト用 xlsx にはリンクが無いので markdown 内容は変わらないが、
+    #  kwargs が引き渡されることを ConversionConfig の TypeError で間接的に
+    #  検査するために、わざと未知のキー指定で例外を確認)
+    with pytest.raises(TypeError):
+        convert_to_markdown(str(xlsx), nonexistent_option=True)
+
+
+def test_convert_to_markdown_default_csv_mode_returns_string(tmp_path):
+    """既定設定 (csv_markdown_enabled=True) でも markdown は文字列で返る。"""
+    from excel2md import convert_to_markdown
+
+    xlsx = tmp_path / "tiny.xlsx"
+    _build_tiny_xlsx(xlsx)
+    result = convert_to_markdown(str(xlsx))
+    assert isinstance(result["markdown"], str)
+    assert result["markdown"]  # 非空


### PR DESCRIPTION
## Summary

Issue #16 のライブラリ化リファクタを 4 段階で実装。CLI 前提から脱却し、Python ライブラリとして外部から `from excel2md import convert_to_markdown` で呼べる公開 API を提供する。Pyodide / MCP サーバー / Notebook / Web サービスなどから直接利用可能になる。

### 追加された公開 API

```python
from excel2md import ConversionConfig, ExcelConverter, convert_to_markdown

# 1 行で使う
result = convert_to_markdown(open("spec.xlsx", "rb").read())
print(result["markdown"])

# 設定をまとめて再利用
cfg = ConversionConfig(hyperlink_mode="inline", csv_markdown_enabled=False)
conv = ExcelConverter(cfg)
r1 = conv.convert(b1); r2 = conv.convert(b2)
```

### 4 つのコミット

- `a152a14` Phase 1: `ConversionConfig` dataclass (47 フィールド、`from_args` / `to_opts_dict`)
- `3739d0f` Phase 2: `ExcelConverter` クラス (bytes/str/Path 入力対応、tempfile 経由)
- `5d386eb` Phase 3: `convert_to_markdown` ワンショット関数 + `__init__.py` 公開 API 整備
- `84674f4` Phase 4: `runner.run()` 内部を ConversionConfig ベースに置換 (CLI と library で実装を共有)

### 振る舞い不変性の保証

- `runner.run` の opts 辞書構築は `ConversionConfig.to_opts_dict()` に置換したが、`test_config.py::TestOptsDictMatchesRunnerInline` の roundtrip テストで旧 inline 辞書と完全一致を保証
- 既存 CLI 経路 (`uv run python v2.1.1/excel_to_md.py ...`) はそのまま動作

### テスト

311 件 PASS:
- 新規 50 件 (config 27 + converter 12 + public_api 11)
- 既存 261 件 (#24/#25/#14/#15 の回帰テスト含む)

Closes #16

## Test plan

- [x] \`uv run pytest\` — 311 passed
- [x] \`uv build\` — wheel + sdist 生成成功
- [x] クリーン venv で \`pip install dist/excel2md-2.1.1-py3-none-any.whl\` → \`import excel2md; excel2md.__version__\` が "2.1.1" を返す
- [x] CLI \`excel2md --help\` が動作 (entry_points 経由)

🤖 Generated with [Claude Code](https://claude.com/claude-code)