### PR TITLE
issue #16 follow-up: ライブラリ層で sys.exit せず WorkbookOpenError を上げる (PR #32 P1 対応)

### DIFF
--- a/v2.1.1/excel2md/__init__.py
+++ b/v2.1.1/excel2md/__init__.py
@@ -6,6 +6,7 @@ __version__ = "2.1.1"
 # ライブラリとしての公開 API (issue #16)
 from .config import ConversionConfig
 from .converter import ExcelConverter, convert_to_markdown
+from .exceptions import ExcelConversionError, WorkbookOpenError
 
 # Backward-compatible re-exports for the v1.x public API surface
 # (see issue #15 — these symbols moved into submodules in v2.x and stopped
@@ -17,6 +18,8 @@ __all__ = [
     "ConversionConfig",
     "ExcelConverter",
     "convert_to_markdown",
+    "ExcelConversionError",
+    "WorkbookOpenError",
     "is_code_block",
     "build_code_block_from_rows",
 ]

--- a/v2.1.1/excel2md/cli.py
+++ b/v2.1.1/excel2md/cli.py
@@ -5,7 +5,9 @@
 """
 
 import argparse
+import sys
 
+from .exceptions import ExcelConversionError
 from .runner import run
 from . import __version__ as VERSION
 
@@ -84,7 +86,13 @@ def build_argparser():
 def main(argv=None):
     parser = build_argparser()
     args = parser.parse_args(argv)
-    out = run(args.input, args.output, args)
+    try:
+        out = run(args.input, args.output, args)
+    except ExcelConversionError as e:
+        # ライブラリ層は例外を上げるが、CLI としては従来どおり stderr に
+        # メッセージを出して exit code 2 で終える。
+        print(f"[ERROR] {e}", file=sys.stderr)
+        sys.exit(2)
     print(out)
 
 if __name__ == "__main__":

--- a/v2.1.1/excel2md/exceptions.py
+++ b/v2.1.1/excel2md/exceptions.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""excel2md 公開 API 用の例外階層。
+
+Issue #16 に伴うライブラリ化で、内部処理の失敗を ``sys.exit`` ではなく
+通常の Python 例外として呼び出し元に伝える必要が出たため導入。
+
+CLI (``excel2md.cli.main``) は ``ExcelConversionError`` を捕まえて
+従来どおり exit code 2 で終了する。ライブラリ呼び出し
+(``ExcelConverter`` / ``convert_to_markdown``) ではプロセスを終了させず
+例外として伝播する。
+"""
+from __future__ import annotations
+
+
+class ExcelConversionError(Exception):
+    """excel2md の変換処理に起因するすべての例外の基底クラス。"""
+
+
+class WorkbookOpenError(ExcelConversionError):
+    """xlsx / xlsm の読み込みに失敗したことを表す例外。
+
+    openpyxl の ``load_workbook`` がファイル不在・破損・非対応形式などで
+    例外を上げた場合に送出される。
+    """

--- a/v2.1.1/excel2md/workbook_loader.py
+++ b/v2.1.1/excel2md/workbook_loader.py
@@ -4,19 +4,24 @@
 仕様書参照: §3.1 入力、§4.1 全体処理フロー
 """
 
+from .exceptions import WorkbookOpenError
 from .output import warn, info
 
 
 def load_workbook_safe(path, read_only=False):
+    """xlsx / xlsm を openpyxl で開く。失敗時は ``WorkbookOpenError`` を送出。
+
+    旧来は ``sys.exit(2)`` でプロセスを落としていたが、Issue #16 のライブラリ
+    化に伴い、ライブラリ利用者のプロセスを巻き込まないよう例外送出に変更
+    (CLI 側は ``cli.main`` で例外を捕まえて exit code 2 を維持する)。
+    """
     try:
         from openpyxl import load_workbook
         # read_only=False で fill 等のスタイル参照を確実化
         wb = load_workbook(filename=path, read_only=read_only, data_only=True)
         return wb
     except Exception as e:
-        import sys
-        print(f"[ERROR] Failed to open workbook: {e}", file=sys.stderr)
-        sys.exit(2)
+        raise WorkbookOpenError(f"Failed to open workbook: {e}") from e
 
 
 def a1_from_rc(r: int, c: int) -> str:

--- a/v2.1.1/excel_to_md.py
+++ b/v2.1.1/excel_to_md.py
@@ -9,6 +9,7 @@ from excel2md.runner import run
 from excel2md import __version__ as VERSION
 from excel2md.config import ConversionConfig
 from excel2md.converter import ExcelConverter, convert_to_markdown
+from excel2md.exceptions import ExcelConversionError, WorkbookOpenError
 from excel2md.output import warn, info
 from excel2md.cell_utils import (
     remove_control_chars,
@@ -68,6 +69,8 @@ __all__ = [
     "ConversionConfig",
     "ExcelConverter",
     "convert_to_markdown",
+    "ExcelConversionError",
+    "WorkbookOpenError",
     "warn",
     "info",
     "remove_control_chars",

--- a/v2.1.1/tests/test_converter.py
+++ b/v2.1.1/tests/test_converter.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from excel2md.config import ConversionConfig
 from excel2md.converter import ExcelConverter
+from excel2md.exceptions import ExcelConversionError, WorkbookOpenError
 
 
 # =============================================================
@@ -171,3 +172,52 @@ class TestConvertCsvMarkdownMode:
         result = ExcelConverter().convert(xlsx.read_bytes())
         assert isinstance(result["markdown"], str)
         assert result["markdown"]
+
+
+# =============================================================
+# Error handling — ライブラリ層は SystemExit ではなく例外を上げる
+# (Issue #16 / PR #32 Codex review P1)
+# =============================================================
+
+class TestErrorHandling:
+    """ライブラリとして呼ばれた場合、xlsx 読み込み失敗で
+    プロセスを落とさず ``WorkbookOpenError`` を上げる。"""
+
+    def test_missing_path_raises_workbook_open_error(self, tmp_path):
+        missing = tmp_path / "does-not-exist.xlsx"
+        with pytest.raises(WorkbookOpenError):
+            ExcelConverter().convert(str(missing))
+
+    def test_missing_path_does_not_call_sys_exit(self, tmp_path):
+        """SystemExit に化けていないことを明示的に検査する。"""
+        missing = tmp_path / "nope.xlsx"
+        try:
+            ExcelConverter().convert(str(missing))
+        except SystemExit:
+            pytest.fail("ライブラリ層が SystemExit を投げてはいけない")
+        except WorkbookOpenError:
+            pass
+
+    def test_corrupt_bytes_raises_workbook_open_error(self):
+        with pytest.raises(WorkbookOpenError):
+            ExcelConverter().convert(b"this is not a valid xlsx file")
+
+    def test_workbook_open_error_is_excel_conversion_error(self, tmp_path):
+        """基底 ``ExcelConversionError`` で一括捕捉できる。"""
+        missing = tmp_path / "nope.xlsx"
+        with pytest.raises(ExcelConversionError):
+            ExcelConverter().convert(str(missing))
+
+
+class TestCliExitBehavior:
+    """CLI は従来どおり exit code 2 で死ぬ (例外はライブラリ層で握り、
+    cli.main が exit code に変換する)。"""
+
+    def test_cli_main_exits_with_code_2_on_missing_file(self, tmp_path, capsys):
+        from excel2md.cli import main
+        missing = tmp_path / "no.xlsx"
+        with pytest.raises(SystemExit) as exc_info:
+            main([str(missing)])
+        assert exc_info.value.code == 2
+        captured = capsys.readouterr()
+        assert "Failed to open workbook" in captured.err


### PR DESCRIPTION
## Summary

PR #32 のマージ後に残っていた Codex review **P1** 指摘への追っかけ対応。

[元コメント](https://github.com/elvezjp/excel2md/pull/32#discussion_r3230465926):
> \`ExcelConverter.convert()\` delegates directly to \`runner.run()\` and does not intercept \`SystemExit\`, so library consumers can have their entire process terminated on routine conversion errors. \`load_workbook_safe()\` still calls \`sys.exit(2)\` on open failures — acceptable for CLI but a breaking behavior for the new reusable API; this path should be translated into a regular exception for programmatic callers.

\`load_workbook_safe\` が xlsx 読み込み失敗時に \`sys.exit(2)\` を呼んでいたため、\`ExcelConverter\` / \`convert_to_markdown\` 経由でライブラリ利用すると、不正なパスや壊れた bytes を渡しただけで**呼び出し元プロセス全体が落ちる**破壊的挙動になっていた。Pyodide / MCP サーバー / Notebook / Web サービスからの利用を想定する公開 API としては受け入れがたい。

## 変更内容

- **新規** \`v2.1.1/excel2md/exceptions.py\` — \`ExcelConversionError\` (基底) と \`WorkbookOpenError\` を定義
- \`v2.1.1/excel2md/workbook_loader.py\` — \`sys.exit(2)\` を \`raise WorkbookOpenError(...) from e\` に変更
- \`v2.1.1/excel2md/cli.py\` — \`main()\` で \`ExcelConversionError\` を catch → stderr 出力 → \`sys.exit(2)\` で **既存 CLI の挙動 (exit code 2) を維持**
- \`v2.1.1/excel2md/__init__.py\` / \`v2.1.1/excel_to_md.py\` — 新例外を公開 API に追加
- \`v2.1.1/tests/test_converter.py\` — 新規 5 テスト
  - \`TestErrorHandling\` × 4: 不在パス / 壊れた bytes で \`WorkbookOpenError\` が上がること、\`SystemExit\` に化けないこと、基底 \`ExcelConversionError\` で捕捉できること
  - \`TestCliExitBehavior\` × 1: CLI は依然 exit code 2 で死ぬこと

## 設計上のポイント

- ライブラリ呼び出し → \`WorkbookOpenError\` 伝播 (プロセスは生存)
- CLI 呼び出し → 従来どおり stderr メッセージ + exit code 2 (ユーザー体験は不変)
- 基底 \`ExcelConversionError\` を用意したので、今後 \`load_workbook_safe\` 以外の sys.exit が出てきた場合も同じ階層でまとめられる

## 関連

- PR #32 (Issue #16 ライブラリ化リファクタ — 既マージ)
- Codex review コメント: https://github.com/elvezjp/excel2md/pull/32#pullrequestreview-4276957071
- なお同レビューの **P2** (tempdir のクリーンアップ漏れ) は本 PR のスコープ外。別途対応予定。

## Test plan

- [x] \`uv run pytest\` — 316 passed (旧 311 + 新規 5、回帰なし)
- [ ] レビュー
- [ ] マージ後に動作確認 (\`from excel2md import ExcelConverter, WorkbookOpenError\` で import できること、不正パスで raise されること)

🤖 Generated with [Claude Code](https://claude.com/claude-code)