### PR TITLE
docs: README の相対リンクを GitHub 絶対 URL に変更 (#37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # excel2md
 
-[English](./README.md) | [日本語](./README_ja.md)
+[English](https://github.com/elvezjp/excel2md/blob/main/README.md) | [日本語](https://github.com/elvezjp/excel2md/blob/main/README_ja.md)
 
 [![Elvez](https://img.shields.io/badge/Elvez-Product-3F61A7?style=flat-square)](https://elvez.co.jp/)
 [![IXV Ecosystem](https://img.shields.io/badge/IXV-Ecosystem-3F61A7?style=flat-square)](https://elvez.co.jp/ixv/)
@@ -30,12 +30,12 @@ Excel to Markdown converter. Reads Excel workbooks (.xlsx/.xlsm) and automatical
 
 ## Documentation
 
-- [CHANGELOG.md](CHANGELOG.md) - Version history
-- [CONTRIBUTING.md](CONTRIBUTING.md) - Contribution guidelines
-- [SECURITY.md](SECURITY.md) - Security policy and best practices
-- [v2.2.0/spec.md](v2.2.0/spec.md) - Technical specification (v2.2.0, latest)
-- [v2.1.0/spec.md](v2.1.0/spec.md) - Technical specification (v2.1.0, frozen snapshot)
-- [v1.8/spec.md](v1.8/spec.md) - Technical specification (v1.8)
+- [CHANGELOG.md](https://github.com/elvezjp/excel2md/blob/main/CHANGELOG.md) - Version history
+- [CONTRIBUTING.md](https://github.com/elvezjp/excel2md/blob/main/CONTRIBUTING.md) - Contribution guidelines
+- [SECURITY.md](https://github.com/elvezjp/excel2md/blob/main/SECURITY.md) - Security policy and best practices
+- [v2.2.0/spec.md](https://github.com/elvezjp/excel2md/blob/main/v2.2.0/spec.md) - Technical specification (v2.2.0, latest)
+- [v2.1.0/spec.md](https://github.com/elvezjp/excel2md/blob/main/v2.1.0/spec.md) - Technical specification (v2.1.0, frozen snapshot)
+- [v1.8/spec.md](https://github.com/elvezjp/excel2md/blob/main/v1.8/spec.md) - Technical specification (v1.8)
 
 ## Setup
 
@@ -277,7 +277,7 @@ excel2md/
 
 ## Security
 
-For security concerns, please see [SECURITY.md](SECURITY.md).
+For security concerns, please see [SECURITY.md](https://github.com/elvezjp/excel2md/blob/main/SECURITY.md).
 
 **Key security notes:**
 - Only process Excel files from trusted sources
@@ -287,7 +287,7 @@ For security concerns, please see [SECURITY.md](SECURITY.md).
 
 ## Contributing
 
-Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+Contributions are welcome! See [CONTRIBUTING.md](https://github.com/elvezjp/excel2md/blob/main/CONTRIBUTING.md) for details.
 
 - Report bugs via [GitHub Issues](https://github.com/elvezjp/excel2md/issues)
 - Submit pull requests for improvements
@@ -296,7 +296,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 ## Changelog
 
-See [CHANGELOG.md](CHANGELOG.md) for details.
+See [CHANGELOG.md](https://github.com/elvezjp/excel2md/blob/main/CHANGELOG.md) for details.
 
 ## Background
 
@@ -306,7 +306,7 @@ IXV addresses challenges in understanding, structuring, and utilizing Japanese d
 
 ## License
 
-MIT License - See [LICENSE](LICENSE) for details.
+MIT License - See [LICENSE](https://github.com/elvezjp/excel2md/blob/main/LICENSE) for details.
 
 ## Contact
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,6 +1,6 @@
 # excel2md
 
-[English](./README.md) | [日本語](./README_ja.md)
+[English](https://github.com/elvezjp/excel2md/blob/main/README.md) | [日本語](https://github.com/elvezjp/excel2md/blob/main/README_ja.md)
 
 [![Elvez](https://img.shields.io/badge/Elvez-Product-3F61A7?style=flat-square)](https://elvez.co.jp/)
 [![IXV Ecosystem](https://img.shields.io/badge/IXV-Ecosystem-3F61A7?style=flat-square)](https://elvez.co.jp/ixv/)
@@ -30,12 +30,12 @@ Excel → Markdown 変換ツール。Excelブック（.xlsx/.xlsm）を読み取
 
 ## ドキュメント
 
-- [CHANGELOG_ja.md](CHANGELOG_ja.md) - バージョン履歴
-- [CONTRIBUTING_ja.md](CONTRIBUTING_ja.md) - コントリビューション方法
-- [SECURITY_ja.md](SECURITY_ja.md) - セキュリティポリシーとベストプラクティス
-- [v2.2.0/spec.md](v2.2.0/spec.md) - 技術仕様書（v2.2.0, 最新）
-- [v2.1.0/spec.md](v2.1.0/spec.md) - 技術仕様書（v2.1.0, 凍結スナップショット）
-- [v1.8/spec.md](v1.8/spec.md) - 技術仕様書（v1.8）
+- [CHANGELOG_ja.md](https://github.com/elvezjp/excel2md/blob/main/CHANGELOG_ja.md) - バージョン履歴
+- [CONTRIBUTING_ja.md](https://github.com/elvezjp/excel2md/blob/main/CONTRIBUTING_ja.md) - コントリビューション方法
+- [SECURITY_ja.md](https://github.com/elvezjp/excel2md/blob/main/SECURITY_ja.md) - セキュリティポリシーとベストプラクティス
+- [v2.2.0/spec.md](https://github.com/elvezjp/excel2md/blob/main/v2.2.0/spec.md) - 技術仕様書（v2.2.0, 最新）
+- [v2.1.0/spec.md](https://github.com/elvezjp/excel2md/blob/main/v2.1.0/spec.md) - 技術仕様書（v2.1.0, 凍結スナップショット）
+- [v1.8/spec.md](https://github.com/elvezjp/excel2md/blob/main/v1.8/spec.md) - 技術仕様書（v1.8）
 
 ## セットアップ
 
@@ -278,7 +278,7 @@ excel2md/
 
 ## セキュリティ
 
-セキュリティに関する懸念は [SECURITY_ja.md](SECURITY_ja.md) をご確認ください。
+セキュリティに関する懸念は [SECURITY_ja.md](https://github.com/elvezjp/excel2md/blob/main/SECURITY_ja.md) をご確認ください。
 
 **主要なセキュリティ注意事項:**
 - 信頼できるソースからのExcelファイルのみを処理してください
@@ -288,7 +288,7 @@ excel2md/
 
 ## コントリビューション
 
-コントリビューションを歓迎します！詳細は [CONTRIBUTING_ja.md](CONTRIBUTING_ja.md) をご覧ください。
+コントリビューションを歓迎します！詳細は [CONTRIBUTING_ja.md](https://github.com/elvezjp/excel2md/blob/main/CONTRIBUTING_ja.md) をご覧ください。
 
 - バグ報告は [GitHub Issues](https://github.com/elvezjp/excel2md/issues) へ
 - 改善のためのプルリクエストを提出
@@ -297,7 +297,7 @@ excel2md/
 
 ## 変更履歴
 
-詳細は [CHANGELOG_ja.md](CHANGELOG_ja.md) を参照してください。
+詳細は [CHANGELOG_ja.md](https://github.com/elvezjp/excel2md/blob/main/CHANGELOG_ja.md) を参照してください。
 
 ## 開発の背景
 
@@ -307,7 +307,7 @@ IXVでは、システム開発における日本語の文書について、理�
 
 ## ライセンス
 
-MIT License - 詳細は [LICENSE](LICENSE) を参照してください。
+MIT License - 詳細は [LICENSE](https://github.com/elvezjp/excel2md/blob/main/LICENSE) を参照してください。
 
 ## 問い合わせ先
 


### PR DESCRIPTION
## Summary

- Issue #37 の修正。TestPyPI のプロジェクトページから README 内の各ドキュメントリンクを開くと 404 になる問題を解消
- `README.md` / `README_ja.md` 内のドキュメントへの相対リンクを `https://github.com/elvezjp/excel2md/blob/main/...` の絶対 URL に変更

## 背景

PyPI のプロジェクトページに描画されるのは `pyproject.toml` の `readme` で指定された **`README.md` 1 ファイルのみ**で、リポ内の他の Markdown は PyPI からは配信されない。GitHub の Web UI は同じ Markdown を相対パス解決してくれるが、PyPI にはその仕組みが無いため、相対リンクは全部 404 になる。

ビルド・パッケージング設定の不具合ではなく、PyPI の仕様。

## 方針

修正対象は **`README.md` と `README_ja.md` の 2 ファイル**のみ。他の Markdown (CHANGELOG.md / SECURITY.md / CONTRIBUTING.md / spec.md 等) は GitHub の相対パス解決で動くため、PyPI 公開のためだけに直す必要は無い。

ただし運用ポリシーとして `README.md` と `README_ja.md` は同一構造で揃えておきたいため、`README_ja.md` も対象に含める（PyPI 上では描画されないが、二つを乖離させないための予防的修正）。

絶対 URL の参照先は **すべて main 追従** (`/blob/main/...`) に統一。理由:

- バージョンごとに README の URL を書き換える運用コストを避ける
- リポ内のドキュメントは main で常に最新化されるので、PyPI ユーザーには「常に最新の運用方針が見える」のが妥当

## 変更内容

### README.md / README_ja.md 共通

| 行 (修正前) | 種別 | 修正後 |
|---|---|---|
| L3 言語切替 | `./README.md` / `./README_ja.md` | `blob/main/README.md` / `blob/main/README_ja.md` |
| L33 CHANGELOG | `CHANGELOG[_ja].md` | `blob/main/CHANGELOG[_ja].md` |
| L34 CONTRIBUTING | `CONTRIBUTING[_ja].md` | `blob/main/CONTRIBUTING[_ja].md` |
| L35 SECURITY | `SECURITY[_ja].md` | `blob/main/SECURITY[_ja].md` |
| L36-38 spec.md | `v2.2.0/spec.md` 等 | `blob/main/v2.2.0/spec.md` 等 |
| L280 SECURITY | `SECURITY[_ja].md` | `blob/main/SECURITY[_ja].md` |
| L290 CONTRIBUTING | `CONTRIBUTING[_ja].md` | `blob/main/CONTRIBUTING[_ja].md` |
| L299 CHANGELOG | `CHANGELOG[_ja].md` | `blob/main/CHANGELOG[_ja].md` |
| L309 LICENSE | `LICENSE` | `blob/main/LICENSE` |

`![alt](path)` 形式の記述 (L122, L218, L228) はバッククォート内のコード例（説明文）であり、実際のリンクではないため対象外。

## Test plan

- [x] 残存する相対リンクが無いことを `grep` で確認（バッククォート内のコード例のみ残存、これは仕様通り）
- [x] `uv build` で wheel/sdist 生成成功
- [x] `twine check dist/*` PASSED
- [ ] 本 PR マージ後、TestPyPI に rc バージョンで再リハするか、本番 PyPI 公開後にプロジェクトページのリンクを目視確認

## 関連 Issue

- Closes #37
- 関連: #38 (verify_csv_markdown 同梱漏れバグ) → #39 で対応中

🤖 Generated with [Claude Code](https://claude.com/claude-code)