### PR TITLE
fix(v2.2.1): ライブラリ層で sys.exit せず WorkbookOpenError を raise (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.2.1] - Unreleased
 
+### Added
+- **Library-level exception types: `ExcelConversionError` (base) and `WorkbookOpenError`** ([#36](https://github.com/elvezjp/excel2md/issues/36))
+  - Exposed from both `excel2md` and `excel_to_md` so library consumers can catch conversion errors without inspecting strings
+
+### Changed
+- **`load_workbook_safe()` no longer calls `sys.exit(2)` on open failures; it now raises `WorkbookOpenError` instead** ([#36](https://github.com/elvezjp/excel2md/issues/36))
+  - Previously, passing a bad path or corrupt bytes to `ExcelConverter` / `convert_to_markdown` terminated the caller's entire process — unacceptable for the PyPI-published reusable API (Pyodide / MCP servers / notebooks / web services)
+  - The original openpyxl exception is preserved via `raise ... from e` (accessible as `__cause__`)
+  - CLI behavior is unchanged: `cli.main()` now catches `ExcelConversionError`, prints `[ERROR] ...` to stderr, and exits with code 2 — same user experience as before
+- Bumped `excel2md.__version__` to `"2.2.1"` (was still `"2.2.0"` after the v2.2.0 → v2.2.1 directory copy)
+
 ### Fixed
 - **Fixed CSV markdown leaking content outside the declared print area when out-of-area images existed** ([#14](https://github.com/elvezjp/excel2md/issues/14))
   - `runner.run()` expanded `union_area` to cover every image position reported by `extract_images_from_sheet`, so an image placed outside the print area dragged the CSV output range with it and pulled in unrelated cell values

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -9,6 +9,17 @@
 
 ## [2.2.1] - Unreleased
 
+### 追加
+- **ライブラリ層の例外型: `ExcelConversionError` (基底) と `WorkbookOpenError` を新設** ([#36](https://github.com/elvezjp/excel2md/issues/36))
+  - `excel2md` および `excel_to_md` から公開。ライブラリ利用者は文字列マッチに頼らず例外型で変換エラーを捕捉できる
+
+### 変更
+- **`load_workbook_safe()` がオープン失敗時に `sys.exit(2)` を呼ばず、`WorkbookOpenError` を raise するように変更** ([#36](https://github.com/elvezjp/excel2md/issues/36))
+  - 従来は不正なパスや壊れた bytes を `ExcelConverter` / `convert_to_markdown` に渡すと呼び出し元プロセス全体が終了していた。PyPI 公開済みの再利用可能 API としては受け入れがたい挙動 (Pyodide / MCP サーバー / Notebook / Web サービス向け)
+  - 元の openpyxl 例外は `raise ... from e` で保持 (`__cause__` から参照可能)
+  - CLI 挙動は不変: `cli.main()` で `ExcelConversionError` を catch して stderr に `[ERROR] ...` を出力し、exit code 2 で終了する従来挙動を維持
+- `excel2md.__version__` を `"2.2.1"` に更新 (v2.2.0 → v2.2.1 ディレクトリコピー時に `"2.2.0"` のままになっていた)
+
 ### 修正
 - **印刷領域外の画像がある場合に CSV Markdown が印刷領域外のコンテンツを取り込んでしまう問題を修正** ([#14](https://github.com/elvezjp/excel2md/issues/14))
   - `runner.run()` が `extract_images_from_sheet` から返された画像位置をすべて含むように `union_area` を拡張していたため、印刷領域外に置かれた画像が CSV 出力レンジを引きずって広げ、関係のないセル値まで巻き込んでいた

--- a/v2.2.1/excel2md/__init__.py
+++ b/v2.2.1/excel2md/__init__.py
@@ -1,11 +1,14 @@
 # -*- coding: utf-8 -*-
-"""excel2md package (v2.2.0)."""
+"""excel2md package (v2.2.1)."""
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"
 
 # ライブラリとしての公開 API (issue #16)
 from .config import ConversionConfig
 from .converter import ExcelConverter, convert_to_markdown
+
+# Library-level exception types (issue #36)
+from .exceptions import ExcelConversionError, WorkbookOpenError
 
 # Backward-compatible re-exports for the v1.x public API surface
 # (see issue #15 — these symbols moved into submodules in v2.x and stopped
@@ -17,6 +20,8 @@ __all__ = [
     "ConversionConfig",
     "ExcelConverter",
     "convert_to_markdown",
+    "ExcelConversionError",
+    "WorkbookOpenError",
     "is_code_block",
     "build_code_block_from_rows",
 ]

--- a/v2.2.1/excel2md/cli.py
+++ b/v2.2.1/excel2md/cli.py
@@ -5,7 +5,9 @@
 """
 
 import argparse
+import sys
 
+from .exceptions import ExcelConversionError
 from .runner import run
 from . import __version__ as VERSION
 
@@ -84,7 +86,13 @@ def build_argparser():
 def main(argv=None):
     parser = build_argparser()
     args = parser.parse_args(argv)
-    out = run(args.input, args.output, args)
+    try:
+        out = run(args.input, args.output, args)
+    except ExcelConversionError as e:
+        # Issue #36: ライブラリ層は例外を上げるよう変更したが、CLI 利用者から見た
+        # 終了コード (2) とエラーメッセージのフォーマットは従来挙動を維持する。
+        print(f"[ERROR] {e}", file=sys.stderr)
+        sys.exit(2)
     print(out)
 
 if __name__ == "__main__":

--- a/v2.2.1/excel2md/exceptions.py
+++ b/v2.2.1/excel2md/exceptions.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""Exception types for the excel2md library API.
+
+Issue #36: ライブラリ層は ``sys.exit`` を呼ばず、例外を上げる。
+CLI 経路 (``cli.main``) でこれらを catch して終了コードに翻訳する。
+"""
+
+
+class ExcelConversionError(Exception):
+    """Base exception for all excel2md conversion errors.
+
+    ライブラリ利用者はこの基底クラスで一括捕捉できる。
+    今後、開ける以外の段階で復帰不能エラーが追加された場合も
+    このクラスを継承する。
+    """
+
+
+class WorkbookOpenError(ExcelConversionError):
+    """Raised when a workbook cannot be opened (bad path / corrupt bytes / etc.).
+
+    元の openpyxl 例外は ``__cause__`` (``raise ... from e``) として保持される。
+    """

--- a/v2.2.1/excel2md/workbook_loader.py
+++ b/v2.2.1/excel2md/workbook_loader.py
@@ -4,6 +4,7 @@
 仕様書参照: §3.1 入力、§4.1 全体処理フロー
 """
 
+from .exceptions import WorkbookOpenError
 from .output import warn, info
 
 
@@ -14,9 +15,9 @@ def load_workbook_safe(path, read_only=False):
         wb = load_workbook(filename=path, read_only=read_only, data_only=True)
         return wb
     except Exception as e:
-        import sys
-        print(f"[ERROR] Failed to open workbook: {e}", file=sys.stderr)
-        sys.exit(2)
+        # Issue #36: ライブラリ利用者のプロセスを sys.exit で落とさず、例外で伝播する。
+        # CLI 経路では cli.main() がこの例外を catch して exit code 2 に翻訳する。
+        raise WorkbookOpenError(f"Failed to open workbook: {e}") from e
 
 
 def a1_from_rc(r: int, c: int) -> str:

--- a/v2.2.1/excel_to_md.py
+++ b/v2.2.1/excel_to_md.py
@@ -9,6 +9,7 @@ from excel2md.runner import run
 from excel2md import __version__ as VERSION
 from excel2md.config import ConversionConfig
 from excel2md.converter import ExcelConverter, convert_to_markdown
+from excel2md.exceptions import ExcelConversionError, WorkbookOpenError
 from excel2md.output import warn, info
 from excel2md.cell_utils import (
     remove_control_chars,
@@ -68,6 +69,8 @@ __all__ = [
     "ConversionConfig",
     "ExcelConverter",
     "convert_to_markdown",
+    "ExcelConversionError",
+    "WorkbookOpenError",
     "warn",
     "info",
     "remove_control_chars",

--- a/v2.2.1/tests/test_converter.py
+++ b/v2.2.1/tests/test_converter.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from excel2md.config import ConversionConfig
 from excel2md.converter import ExcelConverter
+from excel2md.exceptions import ExcelConversionError, WorkbookOpenError
 
 
 # =============================================================
@@ -171,3 +172,82 @@ class TestConvertCsvMarkdownMode:
         result = ExcelConverter().convert(xlsx.read_bytes())
         assert isinstance(result["markdown"], str)
         assert result["markdown"]
+
+
+# =============================================================
+# Issue #36: ライブラリ層は SystemExit を出さず、例外を上げる
+# =============================================================
+
+
+class TestErrorHandling:
+    """ライブラリ経由 (ExcelConverter / convert_to_markdown) で workbook
+    オープン失敗が起きた場合、SystemExit ではなく WorkbookOpenError を
+    伝播することを保証する。"""
+
+    def test_missing_path_raises_workbook_open_error(self, tmp_path):
+        missing = tmp_path / "does-not-exist.xlsx"
+        with pytest.raises(WorkbookOpenError):
+            ExcelConverter().convert(str(missing))
+
+    def test_corrupt_bytes_raise_workbook_open_error(self):
+        with pytest.raises(WorkbookOpenError):
+            ExcelConverter().convert(b"not a real xlsx file")
+
+    def test_does_not_raise_system_exit(self, tmp_path):
+        """SystemExit に化けないことを明示的に保証する (Issue #36 リグレッション)。"""
+        missing = tmp_path / "does-not-exist.xlsx"
+        try:
+            ExcelConverter().convert(str(missing))
+        except SystemExit:
+            pytest.fail("ExcelConverter.convert() must not raise SystemExit")
+        except WorkbookOpenError:
+            pass  # expected
+
+    def test_catchable_by_base_class(self, tmp_path):
+        """ExcelConversionError 基底で一括捕捉できる。"""
+        missing = tmp_path / "does-not-exist.xlsx"
+        with pytest.raises(ExcelConversionError):
+            ExcelConverter().convert(str(missing))
+
+    def test_original_exception_is_chained(self, tmp_path):
+        """``raise ... from e`` で元の openpyxl 例外が ``__cause__`` に
+        保持されている。"""
+        missing = tmp_path / "does-not-exist.xlsx"
+        with pytest.raises(WorkbookOpenError) as excinfo:
+            ExcelConverter().convert(str(missing))
+        assert excinfo.value.__cause__ is not None
+
+    def test_convert_to_markdown_propagates_error(self, tmp_path):
+        """ワンショット API (convert_to_markdown) でも同じ例外が上がる。"""
+        from excel2md import convert_to_markdown
+
+        missing = tmp_path / "does-not-exist.xlsx"
+        with pytest.raises(WorkbookOpenError):
+            convert_to_markdown(str(missing))
+
+
+class TestCliExitBehavior:
+    """CLI 経路 (cli.main) からは exit code 2 で死ぬという従来挙動を維持する
+    (Issue #36 では CLI ユーザー体験を変えない方針)。"""
+
+    def test_cli_exits_with_code_2_on_missing_file(self, tmp_path, capsys):
+        from excel2md.cli import main
+
+        missing = tmp_path / "does-not-exist.xlsx"
+        with pytest.raises(SystemExit) as excinfo:
+            main([str(missing)])
+        assert excinfo.value.code == 2
+        captured = capsys.readouterr()
+        assert "[ERROR]" in captured.err
+        assert "Failed to open workbook" in captured.err
+
+    def test_cli_exits_with_code_2_on_corrupt_file(self, tmp_path, capsys):
+        from excel2md.cli import main
+
+        corrupt = tmp_path / "broken.xlsx"
+        corrupt.write_bytes(b"not a real xlsx file")
+        with pytest.raises(SystemExit) as excinfo:
+            main([str(corrupt)])
+        assert excinfo.value.code == 2
+        captured = capsys.readouterr()
+        assert "[ERROR]" in captured.err


### PR DESCRIPTION
## Summary

- PR #32 (ライブラリ化リファクタ) の Codex review **P1** 指摘への対応
- `load_workbook_safe()` が open 失敗時に `sys.exit(2)` を呼んでおり、`ExcelConverter` / `convert_to_markdown` 経由でライブラリ利用された場合、不正なパスや壊れた bytes を渡しただけで**呼び出し元プロセス全体が落ちる**破壊的挙動になっていた
- PyPI 公開済みで Pyodide / MCP サーバー / Notebook / Web サービスからの利用が想定されるため受け入れがたい

> **Note (stacked PR)**: 本 PR は [#45](https://github.com/elvezjp/excel2md/pull/45) (Issue #14 修正) から派生したスタック PR。base は PR #45 のブランチに設定済みで、PR #45 マージ後に自動的に main へ切り替わります。

## 変更内容

### ライブラリ例外型の新設
- **新規** `v2.2.1/excel2md/exceptions.py`
  - `ExcelConversionError` (基底): ライブラリ利用者が一括捕捉できる
  - `WorkbookOpenError` (派生): workbook を開けない場合
  - 元の openpyxl 例外は `raise ... from e` で `__cause__` に保持

### ライブラリ層の挙動変更
- `v2.2.1/excel2md/workbook_loader.py`:
  - `sys.exit(2)` → `raise WorkbookOpenError(...) from e`

### CLI 挙動の維持
- `v2.2.1/excel2md/cli.py`:
  - `main()` で `ExcelConversionError` を catch → stderr に `[ERROR] ...` を出力 → `sys.exit(2)`
  - **CLI ユーザー体験は不変** (終了コード 2、エラーメッセージのフォーマット)

### 公開 API
- `v2.2.1/excel2md/__init__.py` / `v2.2.1/excel_to_md.py`: 新例外を `__all__` に追加
- あわせて、v2.2.0 → v2.2.1 ディレクトリコピー時に取り残されていた `excel2md.__version__` を `"2.2.0"` → `"2.2.1"` に修正

### テスト
`v2.2.1/tests/test_converter.py` に追加:
- `TestErrorHandling` (6件)
  - 不在パス / 壊れた bytes で `WorkbookOpenError` が上がる
  - `SystemExit` に化けない (Issue #36 リグレッションガード)
  - 基底 `ExcelConversionError` で捕捉できる
  - `__cause__` に元 openpyxl 例外が保持される
  - `convert_to_markdown` (ワンショット API) 経由でも伝播
- `TestCliExitBehavior` (2件)
  - 不在パス / 壊れたファイルで CLI は依然 exit code 2 で死ぬ
  - stderr に `[ERROR]` を含むメッセージが出る

## コミット構成

1. `fix(v2.2.1): ライブラリ層で sys.exit せず WorkbookOpenError を raise (#36)` — 実装本体 + テスト
2. `docs: CHANGELOG に Issue #36 (WorkbookOpenError) 対応を追記`

## Test plan

- [x] `uv run pytest v2.2.1/tests/` — 320件 PASS (本 PR で追加した 8件を含む)
- [x] 修正前: 存在しないパスを `ExcelConverter().convert()` に渡すとプロセスが exit code 2 で死ぬ
- [x] 修正後 (ライブラリ): `WorkbookOpenError` が raise され、try/except で捕捉できる
- [x] 修正後 (CLI): 従来どおり stderr に `[ERROR] Failed to open workbook: ...` を出力し、exit code 2 で終了

## 参考

- Codex review コメント: https://github.com/elvezjp/excel2md/pull/32#discussion_r3230465926
- PR #32 (ライブラリ化リファクタ、マージ済み): https://github.com/elvezjp/excel2md/pull/32
- PR #35 (v2.1.1/ 向けに作成→クローズ): https://github.com/elvezjp/excel2md/pull/35

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)